### PR TITLE
Adding pkgconfig template file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,26 @@ CONFIGURE_FILE(VersionInfo.h.in
     @ONLY
     )
 
+CONFIGURE_FILE(libpaho-mqtt3c.pc.in
+   libpaho-mqtt3c.pc
+   @ONLY
+   )
+
+CONFIGURE_FILE(libpaho-mqtt3cs.pc.in
+   libpaho-mqtt3cs.pc
+   @ONLY
+   )
+
+CONFIGURE_FILE(libpaho-mqtta.pc.in
+   libpaho-mqtt3a.pc
+   @ONLY
+   )
+
+CONFIGURE_FILE(libpaho-mqtt3as.pc.in
+   libpaho-mqttas.pc
+   @ONLY
+   )
+
 SET(common_src
   MQTTTime.c
   MQTTProtocolClient.c

--- a/src/libpaho-mqtt3a.pc.in
+++ b/src/libpaho-mqtt3a.pc.in
@@ -1,0 +1,12 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: paho mqtt async library 
+Version: @CLIENT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lpaho-mqtt3a

--- a/src/libpaho-mqtt3as.pc.in
+++ b/src/libpaho-mqtt3as.pc.in
@@ -1,0 +1,12 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: paho mqtt server async library 
+Version: @CLIENT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lpaho-mqtt3as

--- a/src/libpaho-mqtt3c.pc.in
+++ b/src/libpaho-mqtt3c.pc.in
@@ -1,0 +1,12 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: paho mqtt client library 
+Version: @CLIENT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lpaho-mqtt3c

--- a/src/libpaho-mqtt3cs.pc.in
+++ b/src/libpaho-mqtt3cs.pc.in
@@ -1,0 +1,12 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: paho mqtt client synchronous library 
+Version: @CLIENT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lpaho-mqtt3cs

--- a/src/libpaho-mqtta.pc.in
+++ b/src/libpaho-mqtta.pc.in
@@ -1,0 +1,12 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: paho mqtt async library 
+Version: @PROJECT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lpaho-mqtt3a


### PR DESCRIPTION
Currently integrating paho with other projects is made a little harder
due to the lack of pkg-config files, as it prevents utilities like
autotools from using their built in macros to glean library install
switches and paths, especially when installed to non-standard locations.

Add the package config templates to allow use of pkg-config to determine
library install information

Signed-off-by: Neil Horman<nhorman@gmail.com>



