### PR TITLE
Implemented OpenSSL providers support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project("Eclipse Paho C" 
+project("Eclipse Paho C"
   VERSION 1.3.13
   LANGUAGES C
 )
@@ -29,7 +29,7 @@ set(CMAKE_SCRIPTS "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 ## Project Version
-## Previously we read in the version from these files, but now we use the 
+## Previously we read in the version from these files, but now we use the
 ## CMake project setting. We just make sure the files and CMake match.
 file(READ version.major PAHO_VERSION_MAJOR)
 file(READ version.minor PAHO_VERSION_MINOR)
@@ -64,6 +64,7 @@ option(PAHO_ENABLE_TESTING "Build tests and run" TRUE)
 option(PAHO_ENABLE_CPACK "Enable CPack" TRUE)
 option(PAHO_HIGH_PERFORMANCE "Disable tracing and heap tracking" FALSE)
 option(PAHO_USE_SELECT "Revert to select system call instead of poll" FALSE)
+option(PAHO_SSL_PROVIDERS "Enable provider option for OpenSSL" FALSE)
 
 if(PAHO_HIGH_PERFORMANCE)
   add_definitions(-DHIGH_PERFORMANCE=1)
@@ -71,6 +72,10 @@ endif()
 
 if(PAHO_USE_SELECT)
   add_definitions(-DUSE_SELECT=1)
+endif()
+
+if(PAHO_SSL_PROVIDERS)
+  add_definitions(-DOPENSSL_PROVIDERS=1)
 endif()
 
 if(PAHO_WITH_LIBUUID)

--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -599,7 +599,7 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 	}
 	if (options->struct_version != 0 && options->ssl) /* check validity of SSL options structure */
 	{
-		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 5)
+		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 6)
 		{
 			rc = MQTTASYNC_BAD_STRUCTURE;
 			goto exit;
@@ -757,6 +757,11 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			if (m->c->sslopts->CApath)
 				free((void*)m->c->sslopts->CApath);
 		}
+		if (m->c->sslopts->struct_version >= 6)
+		{
+			if (m->c->sslopts->providerName)
+				free((void*)m->c->sslopts->providerName);
+		}
 		free((void*)m->c->sslopts);
 		m->c->sslopts = NULL;
 	}
@@ -805,6 +810,17 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			if (options->ssl->protos)
 				m->c->sslopts->protos = (const unsigned char*)MQTTStrdup((const char*)options->ssl->protos);
 			m->c->sslopts->protos_len = options->ssl->protos_len;
+		}
+		if (m->c->sslopts->struct_version >= 6)
+		{
+			if (options->ssl->providerName) {
+# if OPENSSL_PROVIDERS
+				m->c->sslopts->providerName = MQTTStrdup(options->ssl->providerName);
+# else // OPENSSL_PROVIDERS
+				rc = MQTTASYNC_SSL_NOT_SUPPORTED;
+				goto exit;
+# endif // OPENSSL_PROVIDERS
+			}
 		}
 	}
 #else

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -491,7 +491,7 @@ typedef struct
 #define MQTTAsync_connectData_initializer {{'M', 'Q', 'C', 'D'}, 0, NULL, {0, NULL}}
 
 /**
- * This is a callback function which will allow the client application to update the 
+ * This is a callback function which will allow the client application to update the
  * connection data.
  * @param data The connection data which can be modified by the application.
  * @return Return a non-zero value to update the connect data, zero to keep the same data.
@@ -1073,12 +1073,13 @@ typedef struct
 	/** The eyecatcher for this structure.  Must be MQTS */
 	char struct_id[4];
 
-	/** The version number of this structure. Must be 0, 1, 2, 3, 4 or 5.
+	/** The version number of this structure. Must be [0-6].
 	 * 0 means no sslVersion
 	 * 1 means no verify, CApath
 	 * 2 means no ssl_error_context, ssl_error_cb
 	 * 3 means no ssl_psk_cb, ssl_psk_context, disableDefaultTrustStore
 	 * 4 means no protos, protos_len
+   * 5 means no providerName
 	 */
 	int struct_version;
 
@@ -1177,9 +1178,13 @@ typedef struct
 	 * Exists only if struct_version >= 5
 	 */
 	unsigned int protos_len;
+
+	/** OpenSSL provider to used, NULL if disabled. */
+	const char* providerName;
+
 } MQTTAsync_SSLOptions;
 
-#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
+#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 6, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, NULL }
 
 /** Utility structure where name/value pairs are needed */
 typedef struct

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1285,7 +1285,7 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 			setSocketForSSLrc = SSLSocket_setSocketForSSL(&m->c->net, m->c->sslopts,
 				serverURI, hostname_len);
 
-			if (setSocketForSSLrc != MQTTCLIENT_SUCCESS)
+			if (1 == setSocketForSSLrc)
 			{
 				if (m->c->session != NULL)
 					if ((rc = SSL_set_session(m->c->net.ssl, m->c->session)) != 1)
@@ -1618,6 +1618,11 @@ static MQTTResponse MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectO
 			if (m->c->sslopts->CApath)
 				free((void*)m->c->sslopts->CApath);
 		}
+		if (m->c->sslopts->struct_version >= 6)
+		{
+			if (m->c->sslopts->providerName)
+				free((void*)m->c->sslopts->providerName);
+		}
 		free(m->c->sslopts);
 		m->c->sslopts = NULL;
 	}
@@ -1665,6 +1670,17 @@ static MQTTResponse MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectO
 		{
 		    m->c->sslopts->protos = options->ssl->protos;
 		    m->c->sslopts->protos_len = options->ssl->protos_len;
+		}
+		if (m->c->sslopts->struct_version >= 6)
+		{
+			if (options->ssl->providerName) {
+# if OPENSSL_PROVIDERS
+				m->c->sslopts->providerName = MQTTStrdup(options->ssl->providerName);
+# else // OPENSSL_PROVIDERS
+				rc.reasonCode = MQTTCLIENT_SSL_NOT_SUPPORTED;
+				goto exit;
+# endif // OPENSSL_PROVIDERS
+			}
 		}
 	}
 #endif
@@ -1818,7 +1834,7 @@ MQTTResponse MQTTClient_connectAll(MQTTClient handle, MQTTClient_connectOptions*
 #if defined(OPENSSL)
 	if (options->struct_version != 0 && options->ssl) /* check validity of SSL options structure */
 	{
-		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 5)
+		if (strncmp(options->ssl->struct_id, "MQTS", 4) != 0 || options->ssl->struct_version < 0 || options->ssl->struct_version > 6)
 		{
 			rc.reasonCode = MQTTCLIENT_BAD_STRUCTURE;
 			goto exit;

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -675,12 +675,13 @@ typedef struct
 	/** The eyecatcher for this structure.  Must be MQTS */
 	char struct_id[4];
 
-	/** The version number of this structure. Must be 0, 1, 2, 3, 4 or 5.
+	/** The version number of this structure. Must be [0-6].
 	 * 0 means no sslVersion
 	 * 1 means no verify, CApath
 	 * 2 means no ssl_error_context, ssl_error_cb
 	 * 3 means no ssl_psk_cb, ssl_psk_context, disableDefaultTrustStore
 	 * 4 means no protos, protos_len
+   * 5 means no providerName
 	 */
 	int struct_version;
 
@@ -779,9 +780,13 @@ typedef struct
 	 * Exists only if struct_version >= 5
 	 */
 	unsigned int protos_len;
+
+	/** OpenSSL provider to used, NULL if disabled. */
+	const char* providerName;
+
 } MQTTClient_SSLOptions;
 
-#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
+#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 , NULL}
 
 /**
   * MQTTClient_libraryInfo is used to store details relating to the currently used

--- a/src/MQTTProtocolClient.c
+++ b/src/MQTTProtocolClient.c
@@ -345,7 +345,7 @@ int MQTTProtocol_handlePublishes(void* pack, SOCKET sock)
 	if (publish->header.bits.qos == 1)
 	{
 		Protocol_processPublication(publish, client, 1);
-  
+
 		if (socketHasPendingWrites)
 			rc = MQTTProtocol_queueAck(client, PUBACK, publish->msgId);
 		else
@@ -981,8 +981,13 @@ void MQTTProtocol_freeClient(Clients* client)
 			if (client->sslopts->protos)
 				free((void*)client->sslopts->protos);
 		}
+		if (client->sslopts->struct_version >= 6)
+		{
+			if(client->sslopts->providerName)
+				free((void*)client->sslopts->providerName);
+		}
 		free(client->sslopts);
-			client->sslopts = NULL;
+		client->sslopts = NULL;
 	}
 #endif
 	/* don't free the client structure itself... this is done elsewhere */


### PR DESCRIPTION
Hi guys,

I have implemented support for OpenSSL providers. It's a new feature available from OpenSSL 3.x.x.

Added CMake compile option “-DPAHO_SSL_PROVIDERS”, which translates to “-DOPENSSL_PROVIDERS=1” C/C++ definition turning on OpenSSL providers support.
“MQTTAsync_connectOptions” and “MQTTClient_connectOptions” structures are extended by “providerName” C-string field with provider name. Empty or invalid “providerName” field indicates no provider used.
 
In function “SSLSocket_createContext()” provider is loaded, provider self-test is performed, key is obtained and assigned to certificate by calling SSL_CTX_use_PrivateKey() function. If any of these operations fail, function is cancelled with an error code.

Related Paho MQTT C++ PR: https://github.com/eclipse/paho.mqtt.cpp/pull/517

---

Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


