### PR TITLE
add OpenBSD support

### DIFF
--- a/src/SHA1.c
+++ b/src/SHA1.c
@@ -59,7 +59,7 @@ int SHA1_Final(unsigned char *md, SHA_CTX *c)
 #  include <libkern/OSByteOrder.h>
 #  define htobe32(x) OSSwapHostToBigInt32(x)
 #  define be32toh(x) OSSwapBigToHostInt32(x)
-#elif defined(__FreeBSD__) || defined(__NetBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #  include <sys/endian.h>
 #endif
 #include <string.h>

--- a/src/WebSocket.c
+++ b/src/WebSocket.c
@@ -45,7 +45,7 @@
 #  define be16toh(x) OSSwapBigToHostInt16(x)
 #  define be32toh(x) OSSwapBigToHostInt32(x)
 #  define be64toh(x) OSSwapBigToHostInt64(x)
-#elif defined(__FreeBSD__) || defined(__NetBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #  include <sys/endian.h>
 #elif defined(_WIN32) || defined(_WIN64)
 #  pragma comment(lib, "rpcrt4.lib")

--- a/test/sync_client_test.c
+++ b/test/sync_client_test.c
@@ -204,7 +204,9 @@ START_TIME_TYPE start_clock(void)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test1.c
+++ b/test/test1.c
@@ -145,7 +145,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test10.c
+++ b/test/test10.c
@@ -159,7 +159,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test11.c
+++ b/test/test11.c
@@ -121,7 +121,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test15.c
+++ b/test/test15.c
@@ -147,7 +147,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test2.c
+++ b/test/test2.c
@@ -136,7 +136,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test3.c
+++ b/test/test3.c
@@ -49,7 +49,9 @@ char* persistenceStore = NULL;
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 

--- a/test/test4.c
+++ b/test/test4.c
@@ -116,7 +116,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test45.c
+++ b/test/test45.c
@@ -118,7 +118,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test5.c
+++ b/test/test5.c
@@ -228,7 +228,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test6.c
+++ b/test/test6.c
@@ -172,7 +172,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 2
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test8.c
+++ b/test/test8.c
@@ -95,7 +95,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test9.c
+++ b/test/test9.c
@@ -100,7 +100,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test95.c
+++ b/test/test95.c
@@ -101,7 +101,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test_connect_destroy.c
+++ b/test/test_connect_destroy.c
@@ -135,7 +135,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test_issue373.c
+++ b/test/test_issue373.c
@@ -104,7 +104,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test_mqtt4async.c
+++ b/test/test_mqtt4async.c
@@ -138,7 +138,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test_mqtt4sync.c
+++ b/test/test_mqtt4sync.c
@@ -138,7 +138,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test_persistence.c
+++ b/test/test_persistence.c
@@ -101,7 +101,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/test_sync_session_present.c
+++ b/test/test_sync_session_present.c
@@ -189,7 +189,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];

--- a/test/thread.c
+++ b/test/thread.c
@@ -85,7 +85,9 @@ void getopts(int argc, char** argv)
 #define LOGA_INFO 1
 #include <stdarg.h>
 #include <time.h>
+#if !defined(__OpenBSD__)
 #include <sys/timeb.h>
+#endif
 void MyLog(int LOGA_level, char* format, ...)
 {
 	static char msg_buf[256];


### PR DESCRIPTION
add OpnBSD support.

OpenBSD disables `#include <sys/timeb.h>` in test codes, is this include required for other PC-UNIX? I think only Windows needed.
