### PR TITLE
cross compile friendly cpack deb

### DIFF
--- a/cmake/CPackDebConfig.cmake.in
+++ b/cmake/CPackDebConfig.cmake.in
@@ -1,15 +1,6 @@
 IF (CPACK_GENERATOR MATCHES "DEB")
-    FIND_PROGRAM(DPKG_PROGRAM dpkg DOC "dpkg program of Debian-based systems")
-    IF (DPKG_PROGRAM)
-      EXECUTE_PROCESS(
-        COMMAND ${DPKG_PROGRAM} --print-architecture
-        OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-      )
-    ELSE (DPKG_PROGRAM)
-      MESSAGE(FATAL_ERROR "Could not find an architecture for the package")
-    ENDIF (DPKG_PROGRAM)
-
+    # Allow CPACK_DEBIAN_PACKAGE_ARCHITECTURE to be populated by dpkg
+    # by default if it is not set externally
     EXECUTE_PROCESS(
       COMMAND lsb_release -si
       OUTPUT_VARIABLE CPACK_DEBIAN_DIST_NAME
@@ -17,12 +8,8 @@ IF (CPACK_GENERATOR MATCHES "DEB")
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    IF (DIST_NAME_STATUS)
-       MESSAGE(FATAL_ERROR "Could not find a GNU/Linux distribution name")
-    ENDIF (DIST_NAME_STATUS)
-
-    IF (CPACK_DEBIAN_DIST_NAME STREQUAL "")
-      MESSAGE(FATAL_ERROR "Could not find a GNU/Linux distribution name")
+    IF (DIST_NAME_STATUS OR CPACK_DEBIAN_DIST_NAME STREQUAL "")
+       MESSAGE(WARNING "Could not find a GNU/Linux distribution name")
     ENDIF ()
 
     EXECUTE_PROCESS(
@@ -32,12 +19,8 @@ IF (CPACK_GENERATOR MATCHES "DEB")
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    IF (DIST_NAME_STATUS)
-       MESSAGE(FATAL_ERROR "Could not find a GNU/Linux distribution codename")
-    ENDIF (DIST_NAME_STATUS)
-
-    IF (CPACK_DEBIAN_DIST_CODE STREQUAL "")
-      MESSAGE(FATAL_ERROR "Could not find a GNU/Linux distribution codename")
+    IF (DIST_NAME_STATUS OR CPACK_DEBIAN_DIST_CODE STREQUAL "")
+       MESSAGE(WARNING "Could not find a GNU/Linux distribution codename")
     ENDIF ()
 
     SET(CPACK_PACKAGE_VERSION_MAJOR @PAHO_VERSION_MAJOR@)
@@ -53,7 +36,7 @@ IF (CPACK_GENERATOR MATCHES "DEB")
     SET(PAHO_WITH_SSL @PAHO_WITH_SSL@)
 
     MESSAGE("Package version:   ${PACKAGE_VERSION}")
-    MESSAGE("Package built for: ${CPACK_DEBIAN_DIST_NAME} ${CPACK_DEBIAN_DIST_CODE}")
+    MESSAGE("Package built on: ${CPACK_DEBIAN_DIST_NAME} ${CPACK_DEBIAN_DIST_CODE}")
     IF(PAHO_WITH_SSL)
         MESSAGE("Package built with ssl-enabled binaries too")
     ENDIF()
@@ -67,7 +50,10 @@ IF (CPACK_GENERATOR MATCHES "DEB")
     SET(CPACK_DEBIAN_PACKAGE_MAINTAINER
         "Genis Riera Perez <genis.riera.perez@gmail.com>")
     SET(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Eclipse Paho MQTT C client library")
-    SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    # Default shlibdeps on, but allow it to be disabled externally
+    if (NOT DEFINED CPACK_DEBIAN_PACKAGE_SHLIBDEPS)
+      SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    endif()
     SET(CPACK_DEBIAN_PACKAGE_VERSION ${PACKAGE_VERSION})
     SET(CPACK_DEBIAN_PACKAGE_SECTION "net")
     SET(CPACK_DEBIAN_PACKAGE_CONFLICTS ${CPACK_PACKAGE_NAME})


### PR DESCRIPTION
The current `CpackDebConfig.cmake.in` has some restrictions that make it difficult to use in a Cross compile toolchain setup.
- It requires the `lsb_release` binary to be available or it fails, even though this is just used for an info log
- `CPACK_DEBIAN_PACKAGE_SHLIBDEPS` is forced on, even if it is turned off in the CMake cache
- `CPACK_DEBIAN_PACKAGE_ARCHITECTURE` is forced to be populated from `dpkg --print-architecture` on the compiling system.

These changes should not change behavior for anyone doing a normal packaging flow. However, they introduce additional flexibility to set `CPACK_DEBIAN_PACKAGE_ARCHITECTURE` and `CPACK_DEBIAN_PACKAGE_SHLIBDEPS` manually and have that be respected, as well as turning the fatal error when `lsb_release` is not present into a warning only.