### PR TITLE
Fix: Use thread-safe MQTTAsync_Socket_noPendingWrites in MQTTAsync pe…

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1032,7 +1032,7 @@ static void MQTTProtocol_checkPendingWrites(void)
 		ListElement* le = state.pending_writes.first;
 		while (le)
 		{
-			if (Socket_noPendingWrites(((pending_write*)(le->content))->socket))
+			if (MQTTAsync_Socket_noPendingWrites(((pending_write*)(le->content))->socket))
 			{
 				MQTTProtocol_removePublication(((pending_write*)(le->content))->p);
 				state.pending_writes.current = le;
@@ -2479,7 +2479,7 @@ static void MQTTAsync_closeOnly(Clients* client, enum MQTTReasonCodes reasonCode
 	if (client->net.socket > 0)
 	{
 		MQTTProtocol_checkPendingWrites();
-		if (client->connected && Socket_noPendingWrites(client->net.socket))
+		if (client->connected && MQTTAsync_Socket_noPendingWrites(client->net.socket))
 			MQTTPacket_send_disconnect(client, reasonCode, props);
 		MQTTAsync_lock_mutex(socket_mutex);
 		WebSocket_close(&client->net, WebSocket_CLOSE_NORMAL, NULL);


### PR DESCRIPTION
Hi,
During testing MQTTAsync client under unstable network conditions, I encountered an occasional segmentation fault when the client repeatedly reconnects.
The crash stack trace is:

```
6  @ 0x7f3091a72420 (unknown)
7  @ 0x7f3051148e92 ListUnlink
8  @ 0x7f3051148f61 ListRemove
9  @ 0x7f305112db8c MQTTProtocol_checkPendingWrites
10 @ 0x7f305113273d MQTTAsync_closeOnly
11 @ 0x7f3051132887 MQTTAsync_closeSession
12 @ 0x7f305112d8ee MQTTAsync_checkDisconnect
13 @ 0x7f305112f5f7 MQTTAsync_processCommand
14 @ 0x7f305113083d MQTTAsync_sendThread
```


I suspect this issue is caused by multi-threaded access to the pending write list, and it appears similar to issue #1514.

From the code path:
MQTTAsync_cycle → Socket_getReadySocket → Socket_continueWrites → ListRemove
may clear or modify the pending write list.
Meanwhile, another thread may execute:
MQTTAsync_closeOnly → MQTTProtocol_checkPendingWrites → Socket_noPendingWrites → ListFindItem()
which may operate on the same list at the same time.

I noticed that a new function MQTTAsync_Socket_noPendingWrites was introduced to provide thread-safe behavior.
I have reviewed the relevant code and replaced the thread-unsafe usages inside the async client with the thread-safe version.
Please help check whether this change is appropriate. Thank you!