### PR TITLE
Modify the conditions for successful execution of SSLSocket_setSocketForSSL()

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -2949,7 +2949,7 @@ static int MQTTAsync_connecting(MQTTAsyncs* m)
 			setSocketForSSLrc = SSLSocket_setSocketForSSL(&m->c->net, m->c->sslopts,
 					serverURI, hostname_len);
 
-			if (setSocketForSSLrc != MQTTASYNC_SUCCESS)
+			if (setSocketForSSLrc == 1)
 			{
 				if (m->c->session != NULL)
 					if ((rc = SSL_set_session(m->c->net.ssl, m->c->session)) != 1)

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1309,7 +1309,7 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 			setSocketForSSLrc = SSLSocket_setSocketForSSL(&m->c->net, m->c->sslopts,
 				serverURI, hostname_len);
 
-			if (setSocketForSSLrc != MQTTCLIENT_SUCCESS)
+			if (setSocketForSSLrc == 1)
 			{
 				if (m->c->session != NULL)
 					if ((rc = SSL_set_session(m->c->net.ssl, m->c->session)) != 1)


### PR DESCRIPTION
The `SSLSocket_setSocketForSSL()` function returns 1 upon success, while calls to OpenSSL APIs within the function typically return 0 upon failure. However, OpenSSL API failures may also return other negative values. When an OpenSSL API call returns a value less than 0, using the condition `setSocketForSSLrc != 0` to check if `SSLSocket_setSocketForSSL()` succeeded will result in an error, potentially leading to serious errors in subsequent calls to `SSL_connect`.

