### PR TITLE
Bumped minimum CMake to v3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #     Genis Riera Perez - Add support for building debian package
 #*******************************************************************************/
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project("Eclipse Paho C" 
   VERSION 1.3.15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #     Genis Riera Perez - Add support for building debian package
 #*******************************************************************************/
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.12)
 
 project("Eclipse Paho C" 
   VERSION 1.3.15


### PR DESCRIPTION
Fix for #1608

This bumps the minimum version for CMake to get rid of the deprecation warning when using CMake v4.x.
