### PR TITLE
Enable TLS 1.3 and TLS Min/Max settings

### DIFF
--- a/src/MQTTAsync.c
+++ b/src/MQTTAsync.c
@@ -815,7 +815,11 @@ int MQTTAsync_connect(MQTTAsync handle, const MQTTAsync_connectOptions* options)
 			m->c->sslopts->enabledCipherSuites = MQTTStrdup(options->ssl->enabledCipherSuites);
 		m->c->sslopts->enableServerCertAuth = options->ssl->enableServerCertAuth;
 		if (m->c->sslopts->struct_version >= 1)
+		{
 			m->c->sslopts->sslVersion = options->ssl->sslVersion;
+			m->c->sslopts->tlsMin = options->ssl->tlsMin;
+			m->c->sslopts->tlsMax = options->ssl->tlsMax;
+		}
 		if (m->c->sslopts->struct_version >= 2)
 		{
 			m->c->sslopts->verify = options->ssl->verify;

--- a/src/MQTTAsync.h
+++ b/src/MQTTAsync.h
@@ -1056,6 +1056,7 @@ typedef struct
 #define MQTT_SSL_VERSION_TLS_1_0 1
 #define MQTT_SSL_VERSION_TLS_1_1 2
 #define MQTT_SSL_VERSION_TLS_1_2 3
+#define MQTT_SSL_VERSION_TLS_1_3 4
 
 /**
 * MQTTAsync_sslProperties defines the settings to establish an SSL/TLS connection using the
@@ -1113,10 +1114,24 @@ typedef struct
     int enableServerCertAuth;
 
     /** The SSL/TLS version to use. Specify one of MQTT_SSL_VERSION_DEFAULT (0),
-    * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3).
+    * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2), MQTT_SSL_VERSION_TLS_1_2 (3) or MQTT_SSL_VERSION_TLS_1_3 (4).
     * Only used if struct_version is >= 1.
     */
     int sslVersion;
+
+    /** The TLS maximum version allowed. Specify one of MQTT_SSL_VERSION_TLS_1_0 (1), 
+    * MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3) or MQTT_SSL_VERSION_TLS_1_3 (4).
+    * Ignored if OpenSSL version < 1.1.0 and sslVersion not MQTT_SSL_VERSION_DEFAULT 
+    * Only used if struct_version is >= 1.
+    */
+    int tlsMax;
+
+    /** The TLS minimum version allowed. Specify one of MQTT_SSL_VERSION_TLS_1_0 (1),
+    * MQTT_SSL_VERSION_TLS_1_1 (2), MQTT_SSL_VERSION_TLS_1_2 (3) or MQTT_SSL_VERSION_TLS_1_3 (4).
+    * Ignored if OpenSSL version < 1.1.0 and sslVersion not MQTT_SSL_VERSION_DEFAULT
+    * Only used if struct_version is >= 1.
+    */
+    int tlsMin;
 
     /**
      * Whether to carry out post-connect checks, including that a certificate
@@ -1180,7 +1195,7 @@ typedef struct
 	unsigned int protos_len;
 } MQTTAsync_SSLOptions;
 
-#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
+#define MQTTAsync_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, MQTT_SSL_VERSION_DEFAULT, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
 
 /** Utility structure where name/value pairs are needed */
 typedef struct

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1667,7 +1667,11 @@ static MQTTResponse MQTTClient_connectURI(MQTTClient handle, MQTTClient_connectO
 			m->c->sslopts->enabledCipherSuites = MQTTStrdup(options->ssl->enabledCipherSuites);
 		m->c->sslopts->enableServerCertAuth = options->ssl->enableServerCertAuth;
 		if (m->c->sslopts->struct_version >= 1)
+		{
 			m->c->sslopts->sslVersion = options->ssl->sslVersion;
+			m->c->sslopts->tlsMin = options->ssl->tlsMin;
+			m->c->sslopts->tlsMax = options->ssl->tlsMax;
+		}
 		if (m->c->sslopts->struct_version >= 2)
 		{
 			m->c->sslopts->verify = options->ssl->verify;

--- a/src/MQTTClient.h
+++ b/src/MQTTClient.h
@@ -661,6 +661,7 @@ typedef struct
 #define MQTT_SSL_VERSION_TLS_1_0 1
 #define MQTT_SSL_VERSION_TLS_1_1 2
 #define MQTT_SSL_VERSION_TLS_1_2 3
+#define MQTT_SSL_VERSION_TLS_1_3 4
 
 /**
 * MQTTClient_sslProperties defines the settings to establish an SSL/TLS connection using the
@@ -718,10 +719,24 @@ typedef struct
     int enableServerCertAuth;
 
     /** The SSL/TLS version to use. Specify one of MQTT_SSL_VERSION_DEFAULT (0),
-    * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3).
+    * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2), MQTT_SSL_VERSION_TLS_1_2 (3) or MQTT_SSL_VERSION_TLS_1_3 (4).
     * Only used if struct_version is >= 1.
     */
     int sslVersion;
+
+    /** The TLS maximum version allowed. Specify one of MQTT_SSL_VERSION_TLS_1_0 (1),
+    * MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3) or MQTT_SSL_VERSION_TLS_1_3 (4).
+    * Ignored if OpenSSL version < 1.1.0 and sslVersion not MQTT_SSL_VERSION_DEFAULT
+    * Only used if struct_version is >= 1.
+    */
+    int tlsMax;
+
+    /** The TLS minimum version allowed. Specify one of MQTT_SSL_VERSION_TLS_1_0 (1),
+    * MQTT_SSL_VERSION_TLS_1_1 (2), MQTT_SSL_VERSION_TLS_1_2 (3) or MQTT_SSL_VERSION_TLS_1_3 (4).
+    * Ignored if OpenSSL version < 1.1.0 and sslVersion not MQTT_SSL_VERSION_DEFAULT
+    * Only used if struct_version is >= 1.
+    */
+    int tlsMin;
 
     /**
      * Whether to carry out post-connect checks, including that a certificate
@@ -785,7 +800,7 @@ typedef struct
 	unsigned int protos_len;
 } MQTTClient_SSLOptions;
 
-#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
+#define MQTTClient_SSLOptions_initializer { {'M', 'Q', 'T', 'S'}, 5, NULL, NULL, NULL, NULL, NULL, 1, MQTT_SSL_VERSION_DEFAULT, MQTT_SSL_VERSION_DEFAULT, MQTT_SSL_VERSION_DEFAULT, 0, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0 }
 
 /**
   * MQTTClient_libraryInfo is used to store details relating to the currently used

--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -753,7 +753,7 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 			break;
 		case MQTT_SSL_VERSION_TLS_1_3:
 	#ifdef TLS1_3_VERSION
-			SSL_CTX_set_min_proto_version(net->ctx, TLS1_3_VERSION);
+			SSL_CTX_set_max_proto_version(net->ctx, TLS1_3_VERSION);
 	#endif
 			break;
 		default:

--- a/test/tls-testing/mosquitto.conf
+++ b/test/tls-testing/mosquitto.conf
@@ -4,6 +4,7 @@ log_type notice
 log_type information
 #log_type debug
 
+
 #log_dest file /var/log/mosquitto/tls-testing.log
 
 allow_anonymous true
@@ -56,3 +57,11 @@ listener 18888
 ciphers PSK-AES128-CBC-SHA
 psk_hint Test
 psk_file test/tls-testing/mosquitto.psk
+
+# TLS min/max verification
+listener 18889
+cafile test/tls-testing/keys/all-ca.crt
+certfile test/ssl/server.crt
+keyfile test/ssl/server.key
+require_certificate false
+tls_version tlsv1.2


### PR DESCRIPTION
- Enabled TLS 1.3 if openssl version supports it.
- Introduced min and max TLS settings per default 0 and not used
- when min and max set to > 0  && <= 4 they are only used if:
- - min <= max and
- - openssl version >= 1.1.0 or 
- - sslVersion = 0


