### PR TITLE
Added a .clang-format file and bash script to run it 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,79 @@
+---
+Language: C
+
+# Indentation: tabs, one tab per indent level
+# The Emacs footer in source files specifies indent-tabs-mode: t
+UseTab: ForIndentation
+TabWidth: 4
+IndentWidth: 4
+ContinuationIndentWidth: 8
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWrappedFunctionNames: false
+
+# Braces: Allman style - opening brace on its own line for everything
+BreakBeforeBraces: Allman
+
+# Alignment
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+# Pointer style: mixed in codebase (char* ptr and char *ptr both appear),
+# derive per file with Left as default
+PointerAlignment: Left
+DerivePointerAlignment: true
+
+# Spaces
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpacesBeforeTrailingComments: 1
+
+# Line breaking
+ColumnLimit: 120
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+
+# Includes: preserve existing order, do not sort
+SortIncludes: Never
+IncludeBlocks: Preserve
+
+# Blank lines
+MaxEmptyLinesToKeep: 2
+
+# Comments: do not reflow to preserve manual formatting
+ReflowComments: false
+
+# Penalties for line breaking decisions
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Runs clang format over the whole project tree, excluding the 'build/' directory.
+#
+
+find . -type d \( -path './build' \) -prune -iname '*.h' -o -iname '*.c' | xargs clang-format -i
+


### PR DESCRIPTION
This project has accumulated a number of different coding styles over that last few years (decades?). I personally keep forgetting to turn on tab indenting when I modify some files.

This could be helpful to make the code consistent and keep it that way. I tried to figure out and match the prevailing style, but feel free to make any changes to the way it formats the code. I don't care about any particular style. It would just be nice to keep it consistent, and to format any changes I make before sending a PR.

Note: I would recommend merging branches and PRs before doing a big reformat. And/or also reformatting the branches before attempting to merge. And I also recommend doing a single, isolated commit of just the reformat code. 