### PR TITLE
CMake: fix CMAKE_MODULE_PATH extension declaration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ message(STATUS "CMake version: " ${CMAKE_VERSION})
 message(STATUS "CMake system name: " ${CMAKE_SYSTEM_NAME})
 
 set(CMAKE_SCRIPTS "${PROJECT_SOURCE_DIR}/cmake")
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 
 ## Project Version
 ## Previously we read in the version from these files, but now we use the 


### PR DESCRIPTION
Currently. rewriting the global CMake variable `CMAKE_MODULE_PATH` can break the build of parent CMake project in which paho.mqtt.c is included as a subproject.

Instead of `set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")`, it should by used `list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")` as stated in the [CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_PATH.html).

This will eliminate the need for a patch for the conan package, see https://github.com/conan-io/conan-center-index/blob/9611e90bbad1c3cd274413c00d16aa2fd1df2833/recipes/paho-mqtt-c/all/conanfile.py#L83-L90.