### PR TITLE
#1651 Updated CMake version to v3.12 in test_package and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Remember, though, that not all of these targets may be available. It depends on 
 A sample *CMakeLists.txt* for an application that uses the asynchronous library with encryption support *(paho-mqtt3as)* might look like this:
 
 ```
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 project(MyMQTTApp VERSION 1.0.0 LANGUAGES C)
 
 find_package(eclipse-paho-mqtt-c REQUIRED)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Fix for #1651. Updated CMake minimum version to v3.12 in the test_package subdirectory, and also in the README instructions.
