### PR TITLE
Signal send and receive threads for faster shutdown

### DIFF
--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -2436,6 +2436,8 @@ static void MQTTAsync_stop(void)
 		{
 			int count = 0;
 			MQTTAsync_tostop = 1;
+			Socket_interrupt();          /* wake receive thread from poll() */
+			Thread_signal_evt(send_evt); /* wake send thread from Thread_wait_evt */
 			while ((sendThread_state != STOPPED || receiveThread_state != STOPPED) && MQTTAsync_tostop != 0 && ++count < 100)
 			{
 				MQTTAsync_unlock_mutex(mqttasync_mutex);


### PR DESCRIPTION
This seems to fix #889.

On shutdown, both the send and receive thread are blocked in long (1sec) sleeps. By calling the new `Socket_interrupt()` to wake the receive thread and signaling the `send_evt`, for the send thread, both exit quickly and the destroy/terminate/stop proceeds without delay.

Previously I believed this was caused by the disconnect call, but it's actually the shutdown that gets blocked.