### PR TITLE
Keep the socket status in MQTTClient_cycle

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -2628,7 +2628,7 @@ static MQTTPacket* MQTTClient_cycle(SOCKET* sock, ELAPSED_TIME_TYPE timeout, int
 		/* 0 from getReadySocket indicates no work to do, rc -1 == error */
 #endif
 		start = MQTTTime_start_clock();
-		*sock = Socket_getReadySocket(0, (int)timeout, socket_mutex, rc, &interrupted);
+		*sock = Socket_getReadySocket(0, (int)timeout, socket_mutex, &rc1, &interrupted);
 		*rc = rc1;
 		if (*sock == 0 && timeout >= 100L && MQTTTime_elapsed(start) < (int64_t)10)
 			MQTTTime_sleep(100L);


### PR DESCRIPTION
### Problem

`MQTTClient_cycle()` passes the caller's `rc` pointer to `Socket_getReadySocket()`. The next line then runs `*rc = rc1`. `rc1` is a local that is set to 0 and is never written again. The socket status is therefore discarded, and `*rc` is always 0.

Two things follow from this.

- The callers never see `SOCKET_ERROR`. `MQTTClient_run()`, `MQTTClient_receive()` and `MQTTClient_yield()` each test `rc == SOCKET_ERROR` to close a broken session. That test never passes.
- The guard `if (*sock > 0 && rc1 == 0)` is always true. The function reads and processes packets from a socket that reported an error.

### Change

Pass `&rc1` to `Socket_getReadySocket()`. The existing `*rc = rc1` line then copies the real status to the caller. The guard then tests the real status.

`MQTTAsync_cycle()` in `src/MQTTAsyncUtils.c` already uses this exact pattern. This change makes the two functions match.

### Note on the alternative fix

`rc1 = *rc;` in place of `*rc = rc1;` gives the same behaviour. I chose `&rc1` because it makes the synchronous and the asynchronous code identical.

Deletion of `rc1` is not correct. `rc1` is not dead. The guard reads it, and that guard is the only check of the socket status before the function reads a packet.

### Test

Built with gcc 12 on Debian 12. Static and shared, with OpenSSL, plus an AddressSanitizer build. No new compiler warnings.

`test1` cases 1 to 5 pass against a local broker. Those cases drive `MQTTClient_cycle()` on the receive path.

The commit is signed off.
