### PR TITLE
feat(connect): add bounded IPv4/IPv6 connection racing and fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ option(PAHO_BUILD_DEB_PACKAGE "Build debian package" FALSE)
 option(PAHO_ENABLE_TESTING "Build tests and run" TRUE)
 option(PAHO_ENABLE_CPACK "Enable CPack" TRUE)
 option(PAHO_HIGH_PERFORMANCE "Disable tracing and heap tracking" FALSE)
+option(PAHO_WITH_HAPPY_EYEBALLS "Race IPv4/IPv6 TCP connection candidates" TRUE)
+if(PAHO_WITH_HAPPY_EYEBALLS)
+  add_definitions(-DPAHO_WITH_HAPPY_EYEBALLS)
+endif()
+
 option(PAHO_USE_SELECT "Revert to select system call instead of poll" FALSE)
 option(PAHO_NO_TCP_NODELAY "Don't disable Nagle's algorithm on TCP sockets" FALSE)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(common_src
   Messages.c
   Tree.c
   Socket.c
+  SocketConnect.c
   Log.c
   MQTTPersistence.c
   Thread.c

--- a/src/Clients.h
+++ b/src/Clients.h
@@ -34,6 +34,7 @@
 #include "LinkedList.h"
 #include "MQTTClientPersistence.h"
 #include "Socket.h"
+#include "SocketConnect.h"
 
 /**
  * Stored publication data to minimize copying
@@ -79,6 +80,11 @@ typedef struct
 typedef struct
 {
 	SOCKET socket;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+	SocketConnect* connect;
+	START_TIME_TYPE connect_start;
+	ELAPSED_TIME_TYPE connect_timeout;
+#endif
 	START_TIME_TYPE lastSent;
 	START_TIME_TYPE lastReceived;
 	START_TIME_TYPE lastPing;

--- a/src/MQTTAsyncUtils.c
+++ b/src/MQTTAsyncUtils.c
@@ -1374,6 +1374,10 @@ static int MQTTAsync_processCommand(void)
 			else
 				command->command.details.conn.MQTTVersion = command->client->c->MQTTVersion;
 
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+            command->client->c->net.connect_start = command->command.start_time;
+            command->client->c->net.connect_timeout = (ELAPSED_TIME_TYPE)command->client->connectTimeout * 1000;
+#endif
 			Log(TRACE_PROTOCOL, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, command->command.details.conn.MQTTVersion);
 #if defined(OPENSSL)
 #if defined(__GNUC__) && defined(__linux__)
@@ -1400,7 +1404,7 @@ static int MQTTAsync_processCommand(void)
 			which is indicated by the socket being ready *either* for reading *or* writing.  The next couple of lines
 			make sure we check for writeability as well as readability, otherwise we wait around longer than we need to
 			in Socket_getReadySocket() */
-			if (rc == EINPROGRESS)
+			if (rc == EINPROGRESS && command->client->c->net.socket > 0)
 				Socket_addPendingWrite(command->client->c->net.socket);
 		}
 	}
@@ -2457,6 +2461,9 @@ static void MQTTAsync_stop(void)
 static void MQTTAsync_closeOnly(Clients* client, enum MQTTReasonCodes reasonCode, MQTTProperties* props, int sendDisconnect)
 {
 	FUNC_ENTRY;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    SocketConnect_cancel(&client->net.connect);
+#endif
 	client->good = 0;
 	client->ping_outstanding = 0;
 	client->ping_due = 0;
@@ -3062,8 +3069,14 @@ static MQTTPacket* MQTTAsync_cycle(SOCKET* sock, unsigned long timeout, int* rc)
 {
 	MQTTPacket* pack = NULL;
 	int rc1 = 0;
+    uint64_t registration_id = 0;
 
 	FUNC_ENTRY;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    MQTTAsync_lock_mutex(mqttasync_mutex);
+    timeout = SocketConnect_timeout((int)timeout);
+    MQTTAsync_unlock_mutex(mqttasync_mutex);
+#endif
 #if defined(OPENSSL)
 	if ((*sock = SSLSocket_getPendingRead()) == -1)
 	{
@@ -3072,7 +3085,7 @@ static MQTTPacket* MQTTAsync_cycle(SOCKET* sock, unsigned long timeout, int* rc)
 		int interrupted = 0;
 
 		/* 0 from getReadySocket indicates no work to do, rc -1 == error */
-		*sock = Socket_getReadySocket(0, (int)timeout, socket_mutex, &rc1, &interrupted);
+		*sock = Socket_getReadySocket(0, (int)timeout, socket_mutex, &rc1, &interrupted, &registration_id);
 		*rc = rc1;
 		/*MQTTAsync_lock_mutex(mqttasync_mutex);
 		should_stop = MQTTAsync_tostop;
@@ -3087,6 +3100,35 @@ static MQTTPacket* MQTTAsync_cycle(SOCKET* sock, unsigned long timeout, int* rc)
 	}
 #endif
 	MQTTAsync_lock_mutex(mqttasync_mutex);
+    if (registration_id && !Socket_eventValid(*sock, registration_id))
+        *sock = 0;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    {
+        ListElement* current = NULL;
+        int candidate_event = *sock > 0 &&
+            ListFindItem(MQTTAsync_handles, sock, clientSockCompare) == NULL;
+        SocketConnect_process(*sock, registration_id);
+        if (candidate_event)
+            *sock = 0;
+        while (ListNextElement(MQTTAsync_handles, &current))
+        {
+            MQTTAsyncs* pending = current->content;
+            SOCKET winner;
+            int error;
+            if (SocketConnect_takeResult(&pending->c->net.connect, &winner, &error))
+            {
+                if (error == 0)
+                {
+                    pending->c->net.socket = winner;
+                    MQTTAsync_connecting(pending);
+                }
+                else
+                    nextOrClose(pending, MQTTASYNC_FAILURE,
+                        error == ETIMEDOUT ? "TCP connect timeout" : "TCP candidates exhausted", 0);
+            }
+        }
+    }
+#endif
 	if (*sock > 0 && rc1 == 0)
 	{
 		MQTTAsyncs* m = NULL;

--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -319,6 +319,9 @@ typedef struct
 #endif
 
 	int rc; /* getsockopt return code in connect */
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    int tcp_result_ready;
+#endif
 	evt_type connect_evt;
 	evt_type connack_evt;
 	evt_type suback_evt;
@@ -614,6 +617,9 @@ void MQTTClient_destroy(MQTTClient* handle)
 	if (m->c)
 	{
 		SOCKET saved_socket = m->c->net.socket;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+        SocketConnect_cancel(&m->c->net.connect);
+#endif
 		char* saved_clientid = MQTTStrdup(m->c->clientID);
 #if !defined(NO_PERSISTENCE)
 		MQTTPersistence_close(m->c);
@@ -873,7 +879,7 @@ static thread_return_type WINAPI MQTTClient_run(void* n)
 		timeout = 100L;
 
 		/* find client corresponding to socket */
-		if (ListFindItem(handles, &sock, clientSockCompare) == NULL)
+		if (sock <= 0 || ListFindItem(handles, &sock, clientSockCompare) == NULL)
 		{
 			/* assert: should not happen */
 			continue;
@@ -1120,6 +1126,9 @@ int MQTTClient_setCallbacks(MQTTClient handle, void* context, MQTTClient_connect
 static void MQTTClient_closeSession(Clients* client, enum MQTTReasonCodes reason, MQTTProperties* props, int sendDisconnect)
 {
 	FUNC_ENTRY;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    SocketConnect_cancel(&client->net.connect);
+#endif
 	client->good = 0;
 	client->ping_outstanding = 0;
 	client->ping_due = 0;
@@ -1259,6 +1268,12 @@ static MQTTResponse MQTTClient_connectURIVersion(MQTTClient handle, MQTTClient_c
 		}
 	}
 
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    m->c->net.connect_start = start;
+    m->c->net.connect_timeout = millisecsTimeout;
+    m->tcp_result_ready = 0;
+    Thread_wait_evt(m->connect_evt, 0); /* discard an old attempt's signal */
+#endif
 	Log(TRACE_MIN, -1, "Connecting to serverURI %s with MQTT version %d", serverURI, MQTTVersion);
 #if defined(OPENSSL)
 #if defined(__GNUC__) && defined(__linux__)
@@ -2618,24 +2633,58 @@ static MQTTPacket* MQTTClient_cycle(SOCKET* sock, ELAPSED_TIME_TYPE timeout, int
 	static Ack ack;
 	MQTTPacket* pack = NULL;
 	int rc1 = 0;
+    uint64_t registration_id = 0;
 	int interrupted = 0;
 	START_TIME_TYPE start;
 
 	FUNC_ENTRY;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    Paho_thread_lock_mutex(mqttclient_mutex);
+    timeout = SocketConnect_timeout((int)timeout);
+    Paho_thread_unlock_mutex(mqttclient_mutex);
+#endif
 #if defined(OPENSSL)
 	if ((*sock = SSLSocket_getPendingRead()) == -1)
 	{
 		/* 0 from getReadySocket indicates no work to do, rc -1 == error */
 #endif
 		start = MQTTTime_start_clock();
-		*sock = Socket_getReadySocket(0, (int)timeout, socket_mutex, rc, &interrupted);
+		*sock = Socket_getReadySocket(0, (int)timeout, socket_mutex, &rc1, &interrupted, &registration_id);
 		*rc = rc1;
-		if (*sock == 0 && timeout >= 100L && MQTTTime_elapsed(start) < (int64_t)10)
+#if !defined(PAHO_WITH_HAPPY_EYEBALLS)
+		if (*sock == 0 && !interrupted && timeout >= 100L && MQTTTime_elapsed(start) < (int64_t)10)
 			MQTTTime_sleep(100L);
+#endif
 #if defined(OPENSSL)
 	}
 #endif
 	Paho_thread_lock_mutex(mqttclient_mutex);
+    if (registration_id && !Socket_eventValid(*sock, registration_id))
+        *sock = 0;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+    {
+        ListElement* current = NULL;
+        int candidate_event = *sock > 0 && ListFindItem(handles, sock, clientSockCompare) == NULL;
+        SocketConnect_process(*sock, registration_id);
+        if (candidate_event)
+            *sock = 0;
+        while (ListNextElement(handles, &current))
+        {
+            MQTTClients* pending = current->content;
+            SOCKET winner;
+            int error;
+            if (SocketConnect_takeResult(&pending->c->net.connect, &winner, &error))
+            {
+                pending->c->net.socket = error == 0 ? winner : 0;
+                pending->rc = error;
+                pending->tcp_result_ready = 1;
+                pending->c->connect_state = NOT_IN_PROGRESS;
+                if (running)
+                    Thread_signal_evt(pending->connect_evt);
+            }
+        }
+    }
+#endif
 	if (*sock > 0 && rc1 == 0)
 	{
 		MQTTClients* m = NULL;
@@ -2733,7 +2782,12 @@ static MQTTPacket* MQTTClient_waitfor(MQTTClient handle, int packet_type, int* r
 		if (packet_type == CONNECT)
 		{
 			if ((*rc = Thread_wait_evt(m->connect_evt, (int)timeout)) == 0)
+            {
 				*rc = m->rc;
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+                m->tcp_result_ready = 0;
+#endif
+            }
 		}
 		else if (packet_type == CONNACK)
 			*rc = Thread_wait_evt(m->connack_evt, (int)timeout);
@@ -2752,7 +2806,15 @@ static MQTTPacket* MQTTClient_waitfor(MQTTClient handle, int packet_type, int* r
 		{
 			SOCKET sock = -1;
 			pack = MQTTClient_cycle(&sock, 100L, rc);
-			if (sock == m->c->net.socket)
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+            if (packet_type == CONNECT && m->tcp_result_ready)
+            {
+                *rc = m->rc;
+                m->tcp_result_ready = 0;
+                break;
+            }
+#endif
+			if (sock > 0 && sock == m->c->net.socket)
 			{
 				if (*rc == SOCKET_ERROR)
 					break;

--- a/src/MQTTProtocolOut.c
+++ b/src/MQTTProtocolOut.c
@@ -238,6 +238,10 @@ int MQTTProtocol_connect(const char* address, Clients* aClient, int unixsock, in
 	if (aClient->net.http_proxy) {
 #endif
 		addr_len = MQTTProtocol_addressPort(aClient->net.http_proxy, &port, NULL, PROXY_DEFAULT_PORT);
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+        rc = SocketConnect_start(&aClient->net.connect, aClient->net.http_proxy, addr_len, port,
+            aClient->net.connect_start, aClient->net.connect_timeout);
+#else
 #if defined(__GNUC__) && defined(__linux__)
 		if (timeout < 0)
 			rc = -1;
@@ -246,10 +250,15 @@ int MQTTProtocol_connect(const char* address, Clients* aClient, int unixsock, in
 #else
 		rc = Socket_new(aClient->net.http_proxy, addr_len, port, &(aClient->net.socket));
 #endif
+#endif
 	}
 #if defined(OPENSSL)
 	else if (ssl && aClient->net.https_proxy) {
 		addr_len = MQTTProtocol_addressPort(aClient->net.https_proxy, &port, NULL, PROXY_DEFAULT_PORT);
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+        rc = SocketConnect_start(&aClient->net.connect, aClient->net.https_proxy, addr_len, port,
+            aClient->net.connect_start, aClient->net.connect_timeout);
+#else
 #if defined(__GNUC__) && defined(__linux__)
 		if (timeout < 0)
 			rc = -1;
@@ -257,6 +266,7 @@ int MQTTProtocol_connect(const char* address, Clients* aClient, int unixsock, in
 			rc = Socket_new(aClient->net.https_proxy, addr_len, port, &(aClient->net.socket), timeout);
 #else
 		rc = Socket_new(aClient->net.https_proxy, addr_len, port, &(aClient->net.socket));
+#endif
 #endif
 	}
 #endif
@@ -274,6 +284,10 @@ int MQTTProtocol_connect(const char* address, Clients* aClient, int unixsock, in
 #else
 		addr_len = MQTTProtocol_addressPort(address, &port, NULL, websocket ? WS_DEFAULT_PORT : MQTT_DEFAULT_PORT);
 #endif
+#if defined(PAHO_WITH_HAPPY_EYEBALLS)
+        rc = SocketConnect_start(&aClient->net.connect, address, addr_len, port,
+            aClient->net.connect_start, aClient->net.connect_timeout);
+#else
 #if defined(__GNUC__) && defined(__linux__)
 		if (timeout < 0)
 			rc = -1;
@@ -281,6 +295,7 @@ int MQTTProtocol_connect(const char* address, Clients* aClient, int unixsock, in
 			rc = Socket_new(address, addr_len, port, &(aClient->net.socket), timeout);
 #else
 		rc = Socket_new(address, addr_len, port, &(aClient->net.socket));
+#endif
 #endif
 	}
 	if (rc == EINPROGRESS || rc == EWOULDBLOCK)

--- a/src/Socket.c
+++ b/src/Socket.c
@@ -60,7 +60,7 @@
 #endif
 
 #if defined(USE_SELECT)
-int isReady(int socket, fd_set* read_set, fd_set* write_set);
+int isReady(SOCKET socket, fd_set* read_set, fd_set* write_set);
 int Socket_continueWrites(fd_set* pwset, SOCKET* socket, mutex_type mutex);
 #else
 int isReady(int index);
@@ -90,6 +90,65 @@ static fd_set wset;
 #endif
 
 extern mutex_type socket_mutex;
+
+/* Registrations survive only as long as their FD. Snapshot identities stop a
+ * close/reopen while poll/select is unlocked from reusing an old readiness bit.
+ * All access is under socket_mutex.
+ */
+typedef struct SocketRegistration
+{
+    SOCKET socket;
+    uint64_t registration_id, snapshot_registration_id;
+    int connecting;
+    struct SocketRegistration* next;
+} SocketRegistration;
+static SocketRegistration* registrations;
+static uint64_t next_registration_id;
+
+static SocketRegistration* Socket_registration(SOCKET socket)
+{
+    SocketRegistration* reg;
+    for (reg = registrations; reg && reg->socket != socket; reg = reg->next)
+        ;
+    return reg;
+}
+
+static void Socket_snapshot(void)
+{
+    SocketRegistration* reg;
+    for (reg = registrations; reg; reg = reg->next)
+        reg->snapshot_registration_id = reg->registration_id;
+}
+
+static int Socket_snapshotValid(SOCKET socket)
+{
+    SocketRegistration* reg = Socket_registration(socket);
+    return reg && reg->snapshot_registration_id == reg->registration_id;
+}
+
+static void Socket_unregister(SOCKET socket)
+{
+    SocketRegistration** link = &registrations;
+    while (*link && (*link)->socket != socket)
+        link = &(*link)->next;
+    if (*link)
+    {
+        SocketRegistration* old = *link;
+        *link = old->next;
+        free(old);
+    }
+}
+
+int Socket_eventValid(SOCKET socket, uint64_t registration_id)
+{
+    SocketRegistration* reg;
+    int valid;
+    Paho_thread_lock_mutex(socket_mutex);
+    reg = Socket_registration(socket);
+    valid = reg && registration_id && reg->registration_id == registration_id;
+    Paho_thread_unlock_mutex(socket_mutex);
+    return valid;
+}
 
 /**
  * Set a socket non-blocking, OS independently
@@ -285,7 +344,7 @@ error:
 
 #endif /* _WIN32 */
 
-static SOCKET sockfd[2];
+static SOCKET sockfd[2] = {INVALID_SOCKET, INVALID_SOCKET};
 
 int Socket_pair()
 {
@@ -293,7 +352,11 @@ int Socket_pair()
 
 	FUNC_ENTRY;
 	if ((rc = socketpair(AF_LOCAL, SOCK_STREAM, 0, sockfd)) == 0) /* 0 if successful */
+	{
 		rc = Socket_addSocket(sockfd[0]);
+		if (rc == 0)
+			rc = Socket_setnonblocking(sockfd[1]);
+	}
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -302,6 +365,15 @@ int Socket_interrupt()
 {
 	FUNC_ENTRY;
 	int rc = send(sockfd[1], "\0", 1, 0);
+    if (rc == SOCKET_ERROR)
+    {
+#if defined(_WIN32)
+        if (WSAGetLastError() == WSAEWOULDBLOCK)
+#else
+        if (errno == EWOULDBLOCK || errno == EAGAIN)
+#endif
+            rc = 0; /* a wakeup is already queued */
+    }
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -353,6 +425,7 @@ void Socket_outInitialize(void)
  */
 void Socket_outTerminate(void)
 {
+	int i;
 	FUNC_ENTRY;
 	ListFree(mod_s.connect_pending);
 	ListFree(mod_s.write_pending);
@@ -368,6 +441,20 @@ void Socket_outTerminate(void)
 	if (mod_s.saved.fds_read)
 		free(mod_s.saved.fds_read);
 #endif
+    while (registrations)
+        Socket_unregister(registrations->socket);
+	for (i = 0; i < 2; ++i)
+	{
+		if (sockfd[i] != INVALID_SOCKET)
+		{
+#if defined(_WIN32)
+			closesocket(sockfd[i]);
+#else
+			close(sockfd[i]);
+#endif
+			sockfd[i] = INVALID_SOCKET;
+		}
+	}
 	SocketBuffer_terminate();
 #if defined(_WIN32)
 	WSACleanup();
@@ -376,149 +463,102 @@ void Socket_outTerminate(void)
 }
 
 
+#if !defined(USE_SELECT)
+static int cmpfds(const void* p1, const void* p2)
+{
+    SOCKET a = ((const struct pollfd*)p1)->fd, b = ((const struct pollfd*)p2)->fd;
+    return a == b ? 0 : (a < b ? -1 : 1);
+}
+
+static int cmpsockfds(const void* p1, const void* p2)
+{
+    SOCKET a = *(const SOCKET*)p1, b = ((const struct pollfd*)p2)->fd;
+    return a == b ? 0 : (a < b ? -1 : 1);
+}
+#endif
+
+int Socket_addSocket(SOCKET socket)
+{
+    int rc = SOCKET_ERROR;
+    SocketRegistration* reg = NULL;
+    Paho_thread_lock_mutex(socket_mutex);
+    if (Socket_registration(socket))
+    {
+        rc = 0;
+        goto exit;
+    }
+    if (Socket_setnonblocking(socket) != 0)
+        goto exit;
+    reg = malloc(sizeof(*reg));
+    if (!reg)
+        goto exit;
 #if defined(USE_SELECT)
-/**
- * Add a socket to the list of socket to check with select
- * @param newSd the new socket to add
- */
-int Socket_addSocket(SOCKET newSd)
-{
-	int rc = 0;
-
-	FUNC_ENTRY;
-	if (ListFindItem(mod_s.clientsds, &newSd, intcompare) == NULL) /* make sure we don't add the same socket twice */
-	{
-		if (mod_s.clientsds->count >= FD_SETSIZE)
-		{
-			Log(LOG_ERROR, -1, "addSocket: exceeded FD_SETSIZE %d", FD_SETSIZE);
-			rc = SOCKET_ERROR;
-		}
-		else
-		{
-			SOCKET* pnewSd = (SOCKET*)malloc(sizeof(newSd));
-
-			if (!pnewSd)
-			{
-				rc = PAHO_MEMORY_ERROR;
-				goto exit;
-			}
-			*pnewSd = newSd;
-			if (!ListAppend(mod_s.clientsds, pnewSd, sizeof(newSd)))
-			{
-				free(pnewSd);
-				rc = PAHO_MEMORY_ERROR;
-				goto exit;
-			}
-			FD_SET(newSd, &(mod_s.rset_saved));
-			mod_s.maxfdp1 = max(mod_s.maxfdp1, (int)newSd + 1);
-			rc = Socket_setnonblocking(newSd);
-			if (rc == SOCKET_ERROR)
-				Log(LOG_ERROR, -1, "addSocket: setnonblocking");
-		}
-	}
-	else
-		Log(LOG_ERROR, -1, "addSocket: socket %d already in the list", newSd);
-
-exit:
-	FUNC_EXIT_RC(rc);
-	return rc;
-}
-#else
-static int cmpfds(const void *p1, const void *p2)
-{
-   SOCKET key1 = ((struct pollfd*)p1)->fd;
-   SOCKET key2 = ((struct pollfd*)p2)->fd;
-
-   return (key1 == key2) ? 0 : ((key1 < key2) ? -1 : 1);
-}
-
-
-static int cmpsockfds(const void *p1, const void *p2)
-{
-   int key1 = *(int*)p1;
-   SOCKET key2 = ((struct pollfd*)p2)->fd;
-
-   return (key1 == key2) ? 0 : ((key1 < key2) ? -1 : 1);
-}
-
-
-/**
- * Add a socket to the list of socket to check with select
- * @param newSd the new socket to add
- * @return 0 if successful
- */
-int Socket_addSocket(SOCKET newSd)
-{
-	int rc = 0;
-
-	FUNC_ENTRY;
-	Paho_thread_lock_mutex(socket_mutex);
-	mod_s.nfds++;
-	if (mod_s.fds_read)
-	{
-		void* newPtr = realloc(mod_s.fds_read, mod_s.nfds * sizeof(mod_s.fds_read[0]));
-		if (newPtr == NULL)
-		{
-			free(mod_s.fds_read);
-			mod_s.fds_read = NULL;
-		}
-		else
-		{
-			mod_s.fds_read = newPtr;
-		}
-	}
-	else
-		mod_s.fds_read = malloc(mod_s.nfds * sizeof(mod_s.fds_read[0]));
-	if (!mod_s.fds_read)
-	{
-		rc = PAHO_MEMORY_ERROR;
-		goto exit;
-	}
-	if (mod_s.fds_write)
-	{
-		void* newPtr = realloc(mod_s.fds_write, mod_s.nfds * sizeof(mod_s.fds_write[0]));
-		if (newPtr == NULL)
-		{
-			free(mod_s.fds_write);
-			mod_s.fds_write = NULL;
-		}
-		else
-		{
-			mod_s.fds_write = newPtr;
-		}
-	}
-	else
-		mod_s.fds_write = malloc(mod_s.nfds * sizeof(mod_s.fds_write[0]));
-	if (!mod_s.fds_write)
-	{
-		rc = PAHO_MEMORY_ERROR;
-		goto exit;
-	}
-
-	mod_s.fds_read[mod_s.nfds - 1].fd = newSd;
-	mod_s.fds_write[mod_s.nfds - 1].fd = newSd;
-#if defined(_WIN32)
-	mod_s.fds_read[mod_s.nfds - 1].events = POLLIN;
-	mod_s.fds_write[mod_s.nfds - 1].events = POLLOUT;
-#else
-	mod_s.fds_read[mod_s.nfds - 1].events = POLLIN | POLLNVAL;
-	mod_s.fds_write[mod_s.nfds - 1].events = POLLOUT;
+    if (mod_s.clientsds->count >= FD_SETSIZE
+#if !defined(_WIN32)
+        || socket >= FD_SETSIZE
 #endif
-
-	/* sort the poll fds array by socket number */
-	qsort(mod_s.fds_read, (size_t)mod_s.nfds, sizeof(mod_s.fds_read[0]), cmpfds);
-	qsort(mod_s.fds_write, (size_t)mod_s.nfds, sizeof(mod_s.fds_write[0]), cmpfds);
-
-	rc = Socket_setnonblocking(newSd);
-	if (rc == SOCKET_ERROR)
-		Log(LOG_ERROR, -1, "addSocket: setnonblocking");
-
-exit:
-	Paho_thread_unlock_mutex(socket_mutex);
-	FUNC_EXIT_RC(rc);
-	return rc;
-}
+        )
+        goto exit;
+    {
+        SOCKET* fd = malloc(sizeof(*fd));
+        if (!fd)
+            goto exit;
+        *fd = socket;
+        if (!ListAppend(mod_s.clientsds, fd, sizeof(*fd)))
+        {
+            free(fd);
+            goto exit;
+        }
+    }
+    FD_SET(socket, &mod_s.rset_saved);
+    mod_s.maxfdp1 = max(mod_s.maxfdp1, (int)socket + 1);
+#else
+    {
+        struct pollfd* reads = malloc((mod_s.nfds + 1) * sizeof(*reads));
+        struct pollfd* writes = malloc((mod_s.nfds + 1) * sizeof(*writes));
+        if (!reads || !writes)
+        {
+            if (reads)
+                free(reads);
+            if (writes)
+                free(writes);
+            goto exit;
+        }
+        if (mod_s.nfds)
+        {
+            memcpy(reads, mod_s.fds_read, mod_s.nfds * sizeof(*reads));
+            memcpy(writes, mod_s.fds_write, mod_s.nfds * sizeof(*writes));
+        }
+        memset(&reads[mod_s.nfds], 0, sizeof(*reads));
+        memset(&writes[mod_s.nfds], 0, sizeof(*writes));
+        reads[mod_s.nfds].fd = writes[mod_s.nfds].fd = socket;
+        reads[mod_s.nfds].events = POLLIN;
+        writes[mod_s.nfds].events = POLLOUT;
+        if (mod_s.fds_read)
+            free(mod_s.fds_read);
+        if (mod_s.fds_write)
+            free(mod_s.fds_write);
+        mod_s.fds_read = reads;
+        mod_s.fds_write = writes;
+        ++mod_s.nfds;
+        qsort(reads, mod_s.nfds, sizeof(*reads), cmpfds);
+        qsort(writes, mod_s.nfds, sizeof(*writes), cmpfds);
+    }
 #endif
+    reg->socket = socket;
+    reg->registration_id = ++next_registration_id;
+    reg->snapshot_registration_id = 0;
+    reg->connecting = 0;
+    reg->next = registrations;
+    registrations = reg;
+    reg = NULL;
+    rc = 0;
+exit:
+    if (reg)
+        free(reg);
+    Paho_thread_unlock_mutex(socket_mutex);
+    return rc;
+}
 
 
 #if defined(USE_SELECT)
@@ -530,12 +570,16 @@ exit:
  * @param write_set the socket write set (see select doc)
  * @return boolean - is the socket ready to go?
  */
-int isReady(int socket, fd_set* read_set, fd_set* write_set)
+int isReady(SOCKET socket, fd_set* read_set, fd_set* write_set)
 {
 	int rc = 1;
 
 	FUNC_ENTRY;
-	if  (ListFindItem(mod_s.connect_pending, &socket, intcompare) && FD_ISSET(socket, write_set))
+	if (socket == sockfd[0] || !Socket_snapshotValid(socket))
+        rc = 0;
+    else if (Socket_registration(socket)->connecting)
+        rc = FD_ISSET(socket, write_set) || FD_ISSET(socket, read_set);
+    else if (ListFindItem(mod_s.connect_pending, &socket, intcompare) && FD_ISSET(socket, write_set))
 		ListRemoveItem(mod_s.connect_pending, &socket, intcompare);
 	else
 		rc = FD_ISSET(socket, read_set) && FD_ISSET(socket, write_set) && Socket_noPendingWrites(socket);
@@ -556,9 +600,11 @@ int isReady(int index)
 
 	FUNC_ENTRY;
 
-	if (*socket == sockfd[0]) /* don't return the interrupting socket */
+	if (*socket == sockfd[0] || !Socket_snapshotValid(*socket)) /* don't return the interrupting socket */
 		rc = 0;
-	else if ((mod_s.saved.fds_read[index].revents & POLLHUP) || (mod_s.saved.fds_read[index].revents & POLLNVAL))
+	else if (Socket_registration(*socket)->connecting)
+        rc = (mod_s.saved.fds_read[index].revents & (POLLIN | POLLOUT | POLLERR | POLLHUP | POLLNVAL)) != 0;
+    else if ((mod_s.saved.fds_read[index].revents & POLLHUP) || (mod_s.saved.fds_read[index].revents & POLLNVAL))
 		; /* signal work to be done if there is an error on the socket */
 	else if  (ListFindItem(mod_s.connect_pending, socket, intcompare) &&
 			(mod_s.saved.fds_write[index].revents & POLLOUT))
@@ -579,6 +625,7 @@ int isReady(int index)
  * @param index
  * @return 1 if the socket has a TCP connect pending, otherwise 0
  */
+#if !defined(USE_SELECT)
 int isConnectPending(int index)
 {
 	int rc = 0;
@@ -594,6 +641,7 @@ int isConnectPending(int index)
 	return rc;
 }
 
+#endif
 
 #if defined(USE_SELECT)
 /**
@@ -604,11 +652,13 @@ int isConnectPending(int index)
  *  @param rc a value other than 0 indicates an error of the returned socket
  *  @return the socket next ready, or 0 if none is ready
  */
-SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* rc)
+SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* rc, int* interrupted, uint64_t* registration_id)
 {
 	SOCKET sock = 0;
 	*rc = 0;
 	int timeout_ms = 1000;
+    *interrupted = 0;
+    *registration_id = 0;
 
 	FUNC_ENTRY;
 	Paho_thread_lock_mutex(mutex);
@@ -622,7 +672,7 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 
 	while (mod_s.cur_clientsds != NULL)
 	{
-		if (isReady(*((int*)(mod_s.cur_clientsds->content)), &(mod_s.rset), &wset))
+		if (isReady(*((SOCKET*)(mod_s.cur_clientsds->content)), &(mod_s.rset), &wset))
 			break;
 		ListNextElement(mod_s.clientsds, &mod_s.cur_clientsds);
 	}
@@ -631,7 +681,7 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 	{
 		static struct timeval zero = {0L, 0L}; /* 0 seconds */
 		int rc1, maxfdp1_saved;
-		fd_set pwset;
+		fd_set pwset, errors;
 		struct timeval timeout_tv = {0L, 0L};
 
 		if (timeout_ms > 0L)
@@ -642,7 +692,9 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 
 		memcpy((void*)&(mod_s.rset), (void*)&(mod_s.rset_saved), sizeof(mod_s.rset));
 		memcpy((void*)&(pwset), (void*)&(mod_s.pending_wset), sizeof(pwset));
+		errors = pwset;
 		maxfdp1_saved = mod_s.maxfdp1;
+        Socket_snapshot();
 		
 		if (maxfdp1_saved == 0)
 		{
@@ -651,13 +703,19 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 		}
 		/* Prevent performance issue by unlocking the socket_mutex while waiting for a ready socket. */
 		Paho_thread_unlock_mutex(mutex);
-		*rc = select(maxfdp1_saved, &(mod_s.rset), &pwset, NULL, &timeout_tv);
+		*rc = select(maxfdp1_saved, &(mod_s.rset), &pwset, &errors, &timeout_tv);
 		Paho_thread_lock_mutex(mutex);
 		if (*rc == SOCKET_ERROR)
 		{
 			Socket_error("read select", 0);
 			goto exit;
 		}
+        if (sockfd[0] != INVALID_SOCKET && FD_ISSET(sockfd[0], &mod_s.rset))
+        {
+            char wake[128];
+            while (recv(sockfd[0], wake, sizeof(wake), 0) > 0)
+                *interrupted = 1;
+        }
 		Log(TRACE_MAX, -1, "Return code %d from read select", *rc);
 
 		if (Socket_continueWrites(&pwset, &sock, mutex) == SOCKET_ERROR)
@@ -673,6 +731,12 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 			*rc = rc1;
 			goto exit;
 		}
+        {
+            SocketRegistration* reg;
+            for (reg = registrations; reg; reg = reg->next)
+                if (reg->connecting && reg->snapshot_registration_id == reg->registration_id && FD_ISSET(reg->socket, &errors))
+                    FD_SET(reg->socket, &wset);
+        }
 		Log(TRACE_MAX, -1, "Return code %d from write select", rc1);
 
 		if (*rc == 0 && rc1 == 0)
@@ -684,7 +748,7 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 		mod_s.cur_clientsds = mod_s.clientsds->first;
 		while (mod_s.cur_clientsds != NULL)
 		{
-			int cursock = *((int*)(mod_s.cur_clientsds->content));
+			SOCKET cursock = *((SOCKET*)(mod_s.cur_clientsds->content));
 			if (isReady(cursock, &(mod_s.rset), &wset))
 				break;
 			ListNextElement(mod_s.clientsds, &mod_s.cur_clientsds);
@@ -696,10 +760,14 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 		sock = 0;
 	else
 	{
-		sock = *((int*)(mod_s.cur_clientsds->content));
+		sock = *((SOCKET*)(mod_s.cur_clientsds->content));
 		ListNextElement(mod_s.clientsds, &mod_s.cur_clientsds);
 	}
 exit:
+    if (sock > 0 && Socket_snapshotValid(sock))
+        *registration_id = Socket_registration(sock)->snapshot_registration_id;
+    else
+        sock = 0;
 	Paho_thread_unlock_mutex(mutex);
 	FUNC_EXIT_RC(sock);
 	return sock;
@@ -713,11 +781,13 @@ exit:
  *  @param rc a value other than 0 indicates an error of the returned socket
  *  @return the socket next ready, or 0 if none is ready
  */
-SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* rc, int* interrupted)
+SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* rc, int* interrupted, uint64_t* registration_id)
 {
 	SOCKET sock = 0;
 	*rc = 0;
 	int timeout_ms = 1000;
+    *interrupted = 0;
+    *registration_id = 0;
 
 	FUNC_ENTRY;
 	Paho_thread_lock_mutex(mutex);
@@ -740,65 +810,33 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 	{
 		int rc1 = 0;
 
-		if (mod_s.nfds != mod_s.saved.nfds)
-		{
-			mod_s.saved.nfds = mod_s.nfds;
-			if (mod_s.nfds == 0)
-			{
-				if (mod_s.saved.fds_read)
-				{
-					free(mod_s.saved.fds_read);
-					mod_s.saved.fds_read = NULL;
-				}
-			}
-			else if (mod_s.saved.fds_read)
-			{
-				void* newPtr = realloc(mod_s.saved.fds_read, mod_s.nfds * sizeof(struct pollfd));
-				if (newPtr == NULL)
-				{
-					free(mod_s.saved.fds_read);
-					mod_s.saved.fds_read = NULL;
-				}
-				else
-				{
-					mod_s.saved.fds_read = newPtr;
-				}
-			}
-			else
-				mod_s.saved.fds_read = malloc(mod_s.nfds * sizeof(struct pollfd));
-
-			if (mod_s.nfds == 0)
-			{
-				if (mod_s.saved.fds_write)
-				{
-					free(mod_s.saved.fds_write);
-					mod_s.saved.fds_write = NULL;
-				}
-			}
-			else if (mod_s.saved.fds_write)
-			{
-				void* newPtr = realloc(mod_s.saved.fds_write, mod_s.nfds * sizeof(struct pollfd));
-				if (newPtr == NULL)
-				{
-					free(mod_s.saved.fds_write);
-					mod_s.saved.fds_write = NULL;
-				}
-				else
-				{
-					mod_s.saved.fds_write = newPtr;
-				}
-			}
-			else
-				mod_s.saved.fds_write = malloc(mod_s.nfds * sizeof(struct pollfd));
-		}
-		if (mod_s.fds_read == NULL)
-			mod_s.saved.fds_read = NULL;
-		else
-			memcpy(mod_s.saved.fds_read, mod_s.fds_read, mod_s.nfds * sizeof(struct pollfd));
-		if (mod_s.fds_write == NULL)
-			mod_s.saved.fds_write = NULL;
-		else
-			memcpy(mod_s.saved.fds_write, mod_s.fds_write, mod_s.nfds * sizeof(struct pollfd));
+        if (mod_s.nfds != mod_s.saved.nfds)
+        {
+            struct pollfd* reads = malloc(mod_s.nfds * sizeof(*reads));
+            struct pollfd* writes = malloc(mod_s.nfds * sizeof(*writes));
+            if (mod_s.nfds && (!reads || !writes))
+            {
+                if (reads)
+                    free(reads);
+                if (writes)
+                    free(writes);
+                *rc = SOCKET_ERROR;
+                goto exit;
+            }
+            if (mod_s.saved.fds_read)
+                free(mod_s.saved.fds_read);
+            if (mod_s.saved.fds_write)
+                free(mod_s.saved.fds_write);
+            mod_s.saved.fds_read = reads;
+            mod_s.saved.fds_write = writes;
+            mod_s.saved.nfds = mod_s.nfds;
+        }
+        if (mod_s.nfds)
+        {
+            memcpy(mod_s.saved.fds_read, mod_s.fds_read, mod_s.nfds * sizeof(struct pollfd));
+            memcpy(mod_s.saved.fds_write, mod_s.fds_write, mod_s.nfds * sizeof(struct pollfd));
+        }
+        Socket_snapshot();
 
 		if (mod_s.saved.nfds == 0)
 		{
@@ -818,7 +856,8 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 		mod_s.saved.cur_fd = 0;
 		while (mod_s.saved.cur_fd != -1)
 		{
-			if (isConnectPending(mod_s.saved.cur_fd))
+			if (isConnectPending(mod_s.saved.cur_fd) &&
+                !Socket_registration(mod_s.saved.fds_read[mod_s.saved.cur_fd].fd)->connecting)
 			{
 				Log(TRACE_MINIMUM, -1, "Socket %d is connecting, reducing timeout from %d, no of sockets %d\n",
 					mod_s.saved.cur_fd, timeout_ms, mod_s.saved.nfds);
@@ -831,11 +870,6 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 			mod_s.saved.cur_fd = (mod_s.saved.cur_fd == mod_s.saved.nfds - 1) ? -1 : mod_s.saved.cur_fd + 1;
 		}
 
-		/* clear interrupt socket - make sure it is unset */
-		{
-			static char dbuf[1];
-			/*int irc = */recv(sockfd[0], dbuf, 1, 0);
-		}
 		/* Prevent performance issue by unlocking the socket_mutex while waiting for a ready socket. */
 		Paho_thread_unlock_mutex(mutex);
 		*rc = poll(mod_s.saved.fds_read, mod_s.saved.nfds, timeout_ms);
@@ -882,6 +916,10 @@ SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* 
 		mod_s.saved.cur_fd = (mod_s.saved.cur_fd == mod_s.saved.nfds - 1) ? -1 : mod_s.saved.cur_fd + 1;
 	}
 exit:
+    if (sock > 0 && Socket_snapshotValid(sock))
+        *registration_id = Socket_registration(sock)->snapshot_registration_id;
+    else
+        sock = 0;
 	Paho_thread_unlock_mutex(mutex);
 	FUNC_EXIT_RC(sock);
 	return sock;
@@ -1202,11 +1240,13 @@ int Socket_close(SOCKET socket)
 	int rc = 0;
 
 	FUNC_ENTRY;
+    Paho_thread_lock_mutex(socket_mutex);
+    Socket_unregister(socket);
 	Socket_close_only(socket);
 	FD_CLR(socket, &(mod_s.rset_saved));
 	if (FD_ISSET(socket, &(mod_s.pending_wset)))
 		FD_CLR(socket, &(mod_s.pending_wset));
-	if (mod_s.cur_clientsds != NULL && *(int*)(mod_s.cur_clientsds->content) == socket)
+	if (mod_s.cur_clientsds != NULL && *(SOCKET*)(mod_s.cur_clientsds->content) == socket)
 		mod_s.cur_clientsds = mod_s.cur_clientsds->next;
 	Socket_abortWrite(socket);
 	SocketBuffer_cleanup(socket);
@@ -1228,11 +1268,12 @@ int Socket_close(SOCKET socket)
 
 		mod_s.maxfdp1 = 0;
 		while (ListNextElement(mod_s.clientsds, &cur_clientsds))
-			mod_s.maxfdp1 = max(*((int*)(cur_clientsds->content)), mod_s.maxfdp1);
+			mod_s.maxfdp1 = max(*((SOCKET*)(cur_clientsds->content)), mod_s.maxfdp1);
 		++(mod_s.maxfdp1);
 		Log(TRACE_MAX, -1, "Reset max fdp1 to %d", mod_s.maxfdp1);
 	}
 exit:
+    Paho_thread_unlock_mutex(socket_mutex);
 	FUNC_EXIT_RC(rc);
 	return rc;
 }
@@ -1244,98 +1285,174 @@ exit:
  */
 int Socket_close(SOCKET socket)
 {
-	struct pollfd* fd;
-	int rc = 0;
-
-	FUNC_ENTRY;
-	Paho_thread_lock_mutex(socket_mutex);
-	Socket_close_only(socket);
-	Socket_abortWrite(socket);
-	SocketBuffer_cleanup(socket);
-	ListRemoveItem(mod_s.connect_pending, &socket, intcompare);
-	ListRemoveItem(mod_s.write_pending, &socket, intcompare);
-
-	if (mod_s.nfds == 0)
-		goto exit;
-
-	fd = bsearch(&socket, mod_s.fds_read, (size_t)mod_s.nfds, sizeof(mod_s.fds_read[0]), cmpsockfds);
-	if (fd)
-	{
-		struct pollfd* last_fd = &mod_s.fds_read[mod_s.nfds - 1];
-
-		if (--mod_s.nfds == 0)
-		{
-			free(mod_s.fds_read);
-			mod_s.fds_read = NULL;
-		}
-		else
-		{
-			if (fd != last_fd)
-			{
-				/* shift array to remove the socket in question */
-				memmove(fd, fd + 1, (mod_s.nfds - (fd - mod_s.fds_read)) * sizeof(mod_s.fds_read[0]));
-			}
-	    void* newPtr = realloc(mod_s.fds_read, sizeof(mod_s.fds_read[0]) * mod_s.nfds);
-		  if (newPtr == NULL)
-		  {
-		    free(mod_s.fds_read);
-		  	mod_s.fds_read = NULL;
-
-				rc = PAHO_MEMORY_ERROR;
-				goto exit;
-		  }
-		  else
-		  {
-		    mod_s.fds_read = newPtr;
-		  }
-		}
-		Log(TRACE_MIN, -1, "Removed socket %d", socket);
-	}
-	else
-		Log(LOG_ERROR, -1, "Failed to remove socket %d", socket);
-
-	fd = bsearch(&socket, mod_s.fds_write, (size_t)(mod_s.nfds+1), sizeof(mod_s.fds_write[0]), cmpsockfds);
-	if (fd)
-	{
-		struct pollfd* last_fd = &mod_s.fds_write[mod_s.nfds];
-
-		if (mod_s.nfds == 0)
-		{
-			free(mod_s.fds_write);
-			mod_s.fds_write = NULL;
-		}
-		else
-		{
-			if (fd != last_fd)
-			{
-				/* shift array to remove the socket in question */
-				memmove(fd, fd + 1, (mod_s.nfds - (fd - mod_s.fds_write)) * sizeof(mod_s.fds_write[0]));
-			}
-			void* newPtr = realloc(mod_s.fds_write, sizeof(mod_s.fds_write[0]) * mod_s.nfds);
-			if (newPtr == NULL)
-			{
-				free(mod_s.fds_write);
-				mod_s.fds_write = NULL;
-
-				rc = PAHO_MEMORY_ERROR;
-				goto exit;
-			}
-			else
-			{
-				mod_s.fds_write = newPtr;
-			}
-		}
-		Log(TRACE_MIN, -1, "Removed socket %d", socket);
-	}
-	else
-		Log(LOG_ERROR, -1, "Failed to remove socket %d", socket);
+    struct pollfd *read_fd, *write_fd;
+    unsigned int count;
+    int rc = 0;
+    FUNC_ENTRY;
+    Paho_thread_lock_mutex(socket_mutex);
+    Socket_unregister(socket);
+    Socket_close_only(socket);
+    Socket_abortWrite(socket);
+    SocketBuffer_cleanup(socket);
+    ListRemoveItem(mod_s.connect_pending, &socket, intcompare);
+    ListRemoveItem(mod_s.write_pending, &socket, intcompare);
+    count = mod_s.nfds;
+    if (!count)
+        goto exit;
+    read_fd = bsearch(&socket, mod_s.fds_read, count, sizeof(*read_fd), cmpsockfds);
+    write_fd = bsearch(&socket, mod_s.fds_write, count, sizeof(*write_fd), cmpsockfds);
+    if (!read_fd || !write_fd)
+    {
+        rc = SOCKET_ERROR;
+        goto exit;
+    }
+    --mod_s.nfds;
+    if (mod_s.nfds == 0)
+    {
+        free(mod_s.fds_read);
+        free(mod_s.fds_write);
+        mod_s.fds_read = mod_s.fds_write = NULL;
+    }
+    else
+    {
+        memmove(read_fd, read_fd + 1, (count - (read_fd - mod_s.fds_read) - 1) * sizeof(*read_fd));
+        memmove(write_fd, write_fd + 1, (count - (write_fd - mod_s.fds_write) - 1) * sizeof(*write_fd));
+        /* Shrinking is unnecessary and must not lose other clients on OOM. */
+    }
 exit:
-	Paho_thread_unlock_mutex(socket_mutex);
-	FUNC_EXIT_RC(rc);
-	return rc;
+    Paho_thread_unlock_mutex(socket_mutex);
+    FUNC_EXIT_RC(rc);
+    return rc;
 }
 #endif
 
+
+/* Resolve only the transport target. TLS continues to use the broker URI. */
+int Socket_resolve(const char* host, size_t length, int port, struct addrinfo** addresses)
+{
+    struct addrinfo hints;
+    char service[6];
+    char* name;
+    int rc;
+    *addresses = NULL;
+    if (!length || port < 1 || port > 65535)
+        return SOCKET_ERROR;
+    if (host[0] == '[')
+    {
+        ++host;
+        --length;
+    }
+    if (length && host[length - 1] == ']')
+        --length;
+    name = malloc(length + 1);
+    if (!name)
+        return SOCKET_ERROR;
+    memcpy(name, host, length);
+    name[length] = '\0';
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    hints.ai_flags = AI_ADDRCONFIG;
+    snprintf(service, sizeof(service), "%d", port);
+    rc = getaddrinfo(name, service, &hints, addresses);
+    free(name);
+    return rc;
+}
+
+void Socket_freeAddresses(struct addrinfo* addresses)
+{
+    freeaddrinfo(addresses);
+}
+
+int Socket_connectAddress(const struct addrinfo* address, SOCKET* output, uint64_t* registration_id)
+{
+    SOCKET socket_fd;
+    SocketRegistration* reg;
+    int rc, opt = 1;
+    *output = INVALID_SOCKET;
+    *registration_id = 0;
+    if (!address->ai_addr ||
+        (address->ai_family == AF_INET && address->ai_addrlen < sizeof(struct sockaddr_in)) ||
+        (address->ai_family == AF_INET6 && address->ai_addrlen < sizeof(struct sockaddr_in6)))
+        return SOCKET_ERROR;
+    socket_fd = socket(address->ai_family, SOCK_STREAM, IPPROTO_TCP);
+    if (socket_fd == INVALID_SOCKET)
+        return Socket_error("socket", socket_fd);
+#if defined(NOSIGPIPE)
+    setsockopt(socket_fd, SOL_SOCKET, SO_NOSIGPIPE, (const char*)&opt, sizeof(opt));
+#endif
+#if !defined(NO_TCP_NODELAY)
+    setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, (const char*)&opt, sizeof(opt));
+#endif
+    if (Socket_addSocket(socket_fd) != 0)
+    {
+#if defined(_WIN32)
+        closesocket(socket_fd);
+#else
+        close(socket_fd);
+#endif
+        return SOCKET_ERROR;
+    }
+    *output = socket_fd;
+    Paho_thread_lock_mutex(socket_mutex);
+    reg = Socket_registration(socket_fd);
+    *registration_id = reg->registration_id;
+    reg->connecting = 1;
+#if defined(USE_SELECT)
+    FD_SET(socket_fd, &mod_s.pending_wset);
+#else
+    {
+        struct pollfd* fd = bsearch(&socket_fd, mod_s.fds_read, mod_s.nfds,
+            sizeof(mod_s.fds_read[0]), cmpsockfds);
+        fd->events |= POLLOUT;
+    }
+#endif
+    Paho_thread_unlock_mutex(socket_mutex);
+    rc = connect(socket_fd, address->ai_addr, (socklen_t)address->ai_addrlen);
+    if (rc == SOCKET_ERROR)
+        rc = Socket_error("connect", socket_fd);
+    Socket_interrupt();
+    return rc;
+}
+
+int Socket_connectResult(SOCKET socket)
+{
+    int error = 0;
+    socklen_t length = sizeof(error);
+    if (getsockopt(socket, SOL_SOCKET, SO_ERROR, (char*)&error, &length) != 0)
+        return Socket_error("getsockopt", socket);
+    if (error == 0)
+    {
+        struct sockaddr_storage peer;
+        length = sizeof(peer);
+        /* SO_ERROR == 0 alone does not prove a still-pending socket connected. */
+        if (getpeername(socket, (struct sockaddr*)&peer, &length) != 0)
+            return EINPROGRESS;
+    }
+    return error;
+}
+
+void Socket_connectComplete(SOCKET socket)
+{
+    SocketRegistration* reg;
+    Paho_thread_lock_mutex(socket_mutex);
+    reg = Socket_registration(socket);
+    if (reg)
+        reg->connecting = 0;
+#if defined(USE_SELECT)
+    FD_CLR(socket, &mod_s.pending_wset);
+#else
+    {
+        struct pollfd* fd = bsearch(&socket, mod_s.fds_read, mod_s.nfds,
+            sizeof(mod_s.fds_read[0]), cmpsockfds);
+        if (fd)
+            fd->events &= ~POLLOUT;
+    }
+#endif
+    ListRemoveItem(mod_s.connect_pending, &socket, intcompare);
+    Paho_thread_unlock_mutex(socket_mutex);
+}
 
 /**
  *  Create a new socket and TCP connect to an address/port

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -141,7 +141,7 @@ typedef struct
 
 void Socket_outInitialize(void);
 void Socket_outTerminate(void);
-SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* rc, int* interrupted);
+SOCKET Socket_getReadySocket(int more_work, int timeout, mutex_type mutex, int* rc, int* interrupted, uint64_t* registration_id);
 int Socket_getch(SOCKET socket, char* c);
 char *Socket_getdata(SOCKET socket, size_t bytes, size_t* actual_len, int* rc);
 int Socket_putdatas(SOCKET socket, char* buf0, size_t buf0len, PacketBuffers bufs);
@@ -169,6 +169,13 @@ void Socket_setWriteCompleteCallback(Socket_writeComplete*);
 typedef void Socket_writeAvailable(SOCKET socket);
 void Socket_setWriteAvailableCallback(Socket_writeAvailable*);
 
+/* Internal TCP candidate and event-lifetime helpers. */
+int Socket_resolve(const char* host, size_t length, int port, struct addrinfo** addresses);
+void Socket_freeAddresses(struct addrinfo* addresses);
+int Socket_connectAddress(const struct addrinfo* address, SOCKET* socket, uint64_t* registration_id);
+int Socket_connectResult(SOCKET socket);
+void Socket_connectComplete(SOCKET socket);
+int Socket_eventValid(SOCKET socket, uint64_t registration_id);
 int Socket_interrupt();
 
 #endif /* SOCKET_H */

--- a/src/SocketConnect.c
+++ b/src/SocketConnect.c
@@ -1,0 +1,302 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ *******************************************************************************/
+#include "SocketConnect.h"
+#include "Log.h"
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include "Heap.h"
+
+#define CONNECT_DELAY_MS 200
+#define CONNECT_LAUNCH_LIMIT 8
+
+typedef struct
+{
+    struct addrinfo* next;
+    unsigned int remaining;
+    int family;
+    SOCKET socket;
+    uint64_t registration_id;
+    ELAPSED_TIME_TYPE deadline;
+} ConnectSlot;
+
+struct SocketConnect
+{
+    struct SocketConnect* next;
+    struct addrinfo* addresses;
+    ConnectSlot slots[2];
+    START_TIME_TYPE start;
+    ELAPSED_TIME_TYPE timeout;
+    ELAPSED_TIME_TYPE second_start;
+    uint64_t id;
+    int second_enabled;
+    int done;
+    int error;
+    SOCKET winner;
+};
+
+static SocketConnect* attempts;
+static SocketConnect* cursor;
+static uint64_t next_id;
+
+static void closeSlot(ConnectSlot* slot)
+{
+    if (slot->socket != INVALID_SOCKET)
+        Socket_close(slot->socket);
+    slot->socket = INVALID_SOCKET;
+    slot->registration_id = 0;
+}
+
+static void finish(SocketConnect* attempt, int error, int winner)
+{
+    int i;
+    if (attempt->done)
+        return;
+    attempt->done = 1;
+    attempt->error = error;
+    if (winner >= 0)
+    {
+        attempt->winner = attempt->slots[winner].socket;
+        attempt->slots[winner].socket = INVALID_SOCKET;
+        Socket_connectComplete(attempt->winner);
+    }
+    for (i = 0; i < 2; ++i)
+        closeSlot(&attempt->slots[i]);
+    Log(TRACE_MINIMUM, -1, "TCP attempt %llu complete: rc %d, family %d, elapsed %llu ms",
+        (unsigned long long)attempt->id, error, winner < 0 ? 0 : attempt->slots[winner].family,
+        (unsigned long long)MQTTTime_elapsed(attempt->start));
+}
+
+/* At most one socket is started per visit, so a long list of immediate
+ * failures cannot prevent other attempts or established clients making progress.
+ */
+static int advance(SocketConnect* attempt)
+{
+    int i;
+    ELAPSED_TIME_TYPE elapsed = MQTTTime_elapsed(attempt->start);
+    if (attempt->done)
+        return 0;
+    if (elapsed >= attempt->timeout)
+    {
+        finish(attempt, ETIMEDOUT, -1);
+        return 0;
+    }
+    for (i = 0; i < 2; ++i)
+    {
+        ConnectSlot* slot = &attempt->slots[i];
+        if (slot->socket != INVALID_SOCKET && elapsed >= slot->deadline)
+        {
+            Log(TRACE_MINIMUM, -1, "TCP attempt %llu family %d candidate timeout",
+                (unsigned long long)attempt->id, slot->family);
+            closeSlot(slot);
+            attempt->error = ETIMEDOUT;
+        }
+    }
+    if (elapsed >= attempt->second_start ||
+        (attempt->slots[0].socket == INVALID_SOCKET && attempt->slots[0].remaining == 0))
+        attempt->second_enabled = 1;
+
+    /* When due, the second family takes priority over another quick failure
+     * in the preferred family. Its launch deadline is never restarted.
+     */
+    for (i = 1; i >= 0; --i)
+    {
+        ConnectSlot* slot = &attempt->slots[i];
+        struct addrinfo* address;
+        ELAPSED_TIME_TYPE budget;
+        int rc;
+        if ((i == 1 && !attempt->second_enabled) || slot->socket != INVALID_SOCKET ||
+            slot->remaining == 0)
+            continue;
+        address = slot->next;
+        while (address && address->ai_family != slot->family)
+            address = address->ai_next;
+        slot->next = address->ai_next;
+        --slot->remaining;
+        budget = (attempt->timeout - elapsed) / ((ELAPSED_TIME_TYPE)slot->remaining + 1);
+        if (budget == 0)
+            budget = 1;
+        slot->deadline = elapsed + budget;
+        Log(TRACE_MINIMUM, -1, "TCP attempt %llu start family %d, elapsed %llu ms, budget %llu ms",
+            (unsigned long long)attempt->id, slot->family, (unsigned long long)elapsed,
+            (unsigned long long)budget);
+        rc = Socket_connectAddress(address, &slot->socket, &slot->registration_id);
+        if (rc == 0)
+            finish(attempt, 0, i);
+        else if (rc != EINPROGRESS && rc != EWOULDBLOCK)
+        {
+            closeSlot(slot);
+            attempt->error = rc;
+            if (!attempt->slots[0].remaining && !attempt->slots[1].remaining &&
+                attempt->slots[0].socket == INVALID_SOCKET &&
+                attempt->slots[1].socket == INVALID_SOCKET)
+                finish(attempt, rc, -1);
+        }
+        return 1;
+    }
+    if (attempt->slots[0].remaining == 0 && attempt->slots[1].remaining == 0 &&
+        attempt->slots[0].socket == INVALID_SOCKET && attempt->slots[1].socket == INVALID_SOCKET)
+        finish(attempt, attempt->error, -1);
+    return 0;
+}
+
+int SocketConnect_start(SocketConnect** output, const char* host, size_t length, int port,
+                        START_TIME_TYPE start, ELAPSED_TIME_TYPE timeout)
+{
+    SocketConnect* attempt;
+    struct addrinfo* address;
+    int rc, first = 0;
+    SocketConnect_cancel(output);
+    attempt = malloc(sizeof(*attempt));
+    if (!attempt)
+        return SOCKET_ERROR;
+    memset(attempt, 0, sizeof(*attempt));
+    attempt->winner = INVALID_SOCKET;
+    attempt->slots[0].socket = attempt->slots[1].socket = INVALID_SOCKET;
+    attempt->start = start;
+    attempt->timeout = timeout;
+    attempt->error = SOCKET_ERROR;
+    attempt->id = ++next_id;
+    rc = Socket_resolve(host, length, port, &attempt->addresses);
+    for (address = attempt->addresses; address; address = address->ai_next)
+    {
+        int index;
+        if (address->ai_family != AF_INET && address->ai_family != AF_INET6)
+            continue;
+        if (first == 0)
+            first = address->ai_family;
+        index = address->ai_family == first ? 0 : 1;
+        attempt->slots[index].family = address->ai_family;
+        if (!attempt->slots[index].next)
+            attempt->slots[index].next = address;
+        ++attempt->slots[index].remaining;
+    }
+    attempt->second_start = MQTTTime_elapsed(start) + CONNECT_DELAY_MS;
+    attempt->next = attempts;
+    attempts = attempt;
+    *output = attempt;
+    if (rc != 0 || first == 0)
+        finish(attempt, SOCKET_ERROR, -1);
+    else
+        advance(attempt);
+    Socket_interrupt();
+    /* Even immediate success is consumed by the event loop, after the caller
+     * has installed its connect command and callbacks.
+     */
+    return EINPROGRESS;
+}
+
+void SocketConnect_process(SOCKET ready, uint64_t registration_id)
+{
+    SocketConnect* attempt;
+    unsigned int visits = 0, count = 0, launches = 0;
+    for (attempt = attempts; attempt; attempt = attempt->next)
+    {
+        int i;
+        ++count;
+        if (attempt->done)
+            continue;
+        for (i = 0; i < 2; ++i)
+        {
+            ConnectSlot* slot = &attempt->slots[i];
+            if (ready > 0 && slot->socket == ready && slot->registration_id == registration_id)
+            {
+                int rc = Socket_connectResult(ready);
+                if (rc == 0 && MQTTTime_elapsed(attempt->start) < attempt->timeout)
+                    finish(attempt, 0, i);
+                else if (rc != EINPROGRESS && rc != EWOULDBLOCK)
+                {
+                    attempt->error = rc == 0 ? ETIMEDOUT : rc;
+                    closeSlot(slot);
+                }
+                break;
+            }
+        }
+    }
+    if (!cursor)
+        cursor = attempts;
+    while (cursor && launches < CONNECT_LAUNCH_LIMIT && visits < count)
+    {
+        int launched;
+        attempt = cursor;
+        cursor = cursor->next ? cursor->next : attempts;
+        launched = advance(attempt);
+        launches += launched;
+        visits = launched ? 0 : visits + 1;
+    }
+}
+
+int SocketConnect_timeout(int timeout)
+{
+    SocketConnect* attempt;
+    ELAPSED_TIME_TYPE delay = timeout < 0 ? INT_MAX : (ELAPSED_TIME_TYPE)timeout;
+    for (attempt = attempts; attempt; attempt = attempt->next)
+    {
+        ELAPSED_TIME_TYPE elapsed = MQTTTime_elapsed(attempt->start);
+        ELAPSED_TIME_TYPE due = attempt->timeout;
+        int i;
+        if (attempt->done)
+            return 0;
+        for (i = 0; i < 2; ++i)
+        {
+            ConnectSlot* slot = &attempt->slots[i];
+            if (slot->socket != INVALID_SOCKET)
+            {
+                if (slot->deadline < due)
+                    due = slot->deadline;
+            }
+            else if (slot->remaining)
+            {
+                ELAPSED_TIME_TYPE launch = i == 0 || attempt->second_enabled ||
+                                                   (attempt->slots[0].socket == INVALID_SOCKET &&
+                                                    !attempt->slots[0].remaining)
+                                               ? elapsed
+                                               : attempt->second_start;
+                if (launch < due)
+                    due = launch;
+            }
+        }
+        if (due <= elapsed)
+            return 0;
+        if (due - elapsed < delay)
+            delay = due - elapsed;
+    }
+    return (int)delay;
+}
+
+void SocketConnect_cancel(SocketConnect** output)
+{
+    SocketConnect* attempt = *output;
+    SocketConnect** link = &attempts;
+    if (!attempt)
+        return;
+    *output = NULL;
+    while (*link && *link != attempt)
+        link = &(*link)->next;
+    if (*link)
+        *link = attempt->next;
+    if (cursor == attempt)
+        cursor = attempt->next ? attempt->next : attempts;
+    closeSlot(&attempt->slots[0]);
+    closeSlot(&attempt->slots[1]);
+    if (attempt->winner != INVALID_SOCKET)
+        Socket_close(attempt->winner);
+    if (attempt->addresses)
+        Socket_freeAddresses(attempt->addresses);
+    free(attempt);
+    Socket_interrupt();
+}
+
+int SocketConnect_takeResult(SocketConnect** output, SOCKET* winner, int* error)
+{
+    SocketConnect* attempt = *output;
+    if (!attempt || !attempt->done)
+        return 0;
+    *winner = attempt->winner;
+    *error = attempt->error;
+    attempt->winner = INVALID_SOCKET;
+    SocketConnect_cancel(output);
+    return 1;
+}

--- a/src/SocketConnect.h
+++ b/src/SocketConnect.h
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ *******************************************************************************/
+#ifndef SOCKETCONNECT_H
+#define SOCKETCONNECT_H
+
+#include "Socket.h"
+#include "MQTTTime.h"
+
+typedef struct SocketConnect SocketConnect;
+
+/* All calls are serialized by the owning MQTT library's client mutex.
+ * The socket layer never calls back into this module while holding its mutex.
+ */
+int SocketConnect_start(SocketConnect** attempt, const char* host, size_t length, int port,
+                        START_TIME_TYPE start, ELAPSED_TIME_TYPE timeout);
+void SocketConnect_process(SOCKET ready, uint64_t registration_id);
+int SocketConnect_timeout(int timeout);
+int SocketConnect_takeResult(SocketConnect** attempt, SOCKET* winner, int* error);
+void SocketConnect_cancel(SocketConnect** attempt);
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,12 @@
 project(mqtt-tests C)
 
+# Deterministic connection scheduler tests use socket/clock substitutes.
+add_executable(test_socket_connect test_socket_connect.c ../src/SocketConnect.c)
+target_include_directories(test_socket_connect PRIVATE ../src)
+target_compile_definitions(test_socket_connect PRIVATE NO_HEAP_TRACKING PAHO_MQTT_STATIC)
+add_test(NAME socket-connect-state COMMAND test_socket_connect)
+set_tests_properties(socket-connect-state PROPERTIES TIMEOUT 10 LABELS "happy-eyeballs")
+
 set(MQTT_TEST_BROKER "tcp://localhost:1883" CACHE STRING "Hostname of a test MQTT broker to use")
 set(MQTT_WS_TEST_BROKER "ws://localhost:1883" CACHE STRING "WebSocket connection to a test MQTT broker")
 set(MQTT_TEST_PROXY "tcp://localhost:1884" CACHE STRING "Hostname of the test proxy to use")

--- a/test/test_socket_connect.c
+++ b/test/test_socket_connect.c
@@ -1,0 +1,449 @@
+/* Copyright (c) 2026 Contributors to the Eclipse Foundation
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ * Socket/clock substitutes drive the real connection scheduler.
+ */
+#include "SocketConnect.h"
+#include "Socket.h"
+#include "Log.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static ELAPSED_TIME_TYPE now_ms;
+static int failures;
+static int scenario;
+static int launch_count, close_count, complete_count, interrupt_count;
+static SOCKET launched[64];
+static uint64_t registration_ids[64];
+static int launch_family[64];
+static ELAPSED_TIME_TYPE launch_time[64];
+static int launch_owner[64], live[64], resolve_count;
+static int ready_rc[64];
+static SOCKET next_socket = 100;
+static uint64_t next_registration_id;
+
+#define CHECK(x)                                                                                   \
+    do                                                                                             \
+    {                                                                                              \
+        if (!(x))                                                                                  \
+        {                                                                                          \
+            printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #x);                                    \
+            ++failures;                                                                            \
+            return 0;                                                                              \
+        }                                                                                          \
+    } while (0)
+
+START_TIME_TYPE MQTTTime_start_clock(void)
+{
+    START_TIME_TYPE t = START_TIME_ZERO;
+    return t;
+}
+START_TIME_TYPE MQTTTime_now(void) { return MQTTTime_start_clock(); }
+ELAPSED_TIME_TYPE MQTTTime_elapsed(START_TIME_TYPE ignored)
+{
+    (void)ignored;
+    return now_ms;
+}
+DIFF_TIME_TYPE MQTTTime_difftime(START_TIME_TYPE a, START_TIME_TYPE b)
+{
+    (void)a;
+    (void)b;
+    return (DIFF_TIME_TYPE)now_ms;
+}
+void MQTTTime_sleep(ELAPSED_TIME_TYPE ms) { now_ms += ms; }
+void Log(enum LOG_LEVELS l, int line, const char* f, ...)
+{
+    (void)l;
+    (void)line;
+    (void)f;
+}
+trace_settings_type trace_settings;
+
+static struct addrinfo* node(int family)
+{
+    struct addrinfo* a = (struct addrinfo*)calloc(1, sizeof(*a));
+    a->ai_family = family;
+    return a;
+}
+static void add(struct addrinfo** head, int family)
+{
+    struct addrinfo *a = node(family), *p;
+    if (!*head)
+    {
+        *head = a;
+        return;
+    }
+    for (p = *head; p->ai_next; p = p->ai_next)
+    {
+    }
+    p->ai_next = a;
+}
+
+int Socket_resolve(const char* host, size_t length, int port, struct addrinfo** out)
+{
+    size_t i;
+    struct addrinfo* a;
+    (void)length;
+    (void)port;
+    *out = NULL;
+    ++resolve_count;
+    if (scenario == 9)
+    {
+        now_ms += 30;
+        return EAI_AGAIN;
+    }
+    if (scenario == 10)
+        now_ms += 100;
+    if (strcmp(host, "nine") == 0)
+        for (i = 0; i < 9; ++i)
+            add(out, AF_INET);
+    else if (strcmp(host, "mixed") == 0)
+    {
+        add(out, AF_INET6);
+        add(out, AF_INET);
+        add(out, AF_INET6);
+        add(out, AF_INET);
+    }
+    else if (strcmp(host, "v4") == 0)
+        for (i = 0; i < 10; ++i)
+            add(out, AF_INET);
+    else if (strcmp(host, "v6") == 0)
+        for (i = 0; i < 2; ++i)
+            add(out, AF_INET6);
+    else if (strcmp(host, "v4v6") == 0)
+    {
+        add(out, AF_INET);
+        add(out, AF_INET6);
+        add(out, AF_INET);
+    }
+    else if (strcmp(host, "v6v4") == 0)
+    {
+        add(out, AF_INET6);
+        add(out, AF_INET);
+        add(out, AF_INET6);
+    }
+    else if (strcmp(host, "pair") == 0)
+    {
+        add(out, AF_INET);
+        add(out, AF_INET6);
+    }
+    else
+        add(out, AF_INET);
+    for (a = *out; a; a = a->ai_next)
+        a->ai_flags = resolve_count;
+    return 0;
+}
+void Socket_freeAddresses(struct addrinfo* a)
+{
+    while (a)
+    {
+        struct addrinfo* n = a->ai_next;
+        free(a);
+        a = n;
+    }
+}
+int Socket_connectAddress(const struct addrinfo* a, SOCKET* s, uint64_t* registration_id)
+{
+    int i = launch_count++;
+    next_socket = 100;
+    while (live[next_socket - 100])
+        ++next_socket;
+    *s = next_socket;
+    live[*s - 100] = 1;
+    *registration_id = ++next_registration_id;
+    launched[i] = *s;
+    registration_ids[i] = *registration_id;
+    launch_family[i] = a->ai_family;
+    launch_time[i] = now_ms;
+    launch_owner[i] = a->ai_flags;
+    if (scenario == 4)
+        return ECONNREFUSED;
+    if (scenario == 5 && i == 0)
+        return 0;
+    return scenario == 4 ? ECONNREFUSED : EINPROGRESS;
+}
+int Socket_connectResult(SOCKET s)
+{
+    int i;
+    for (i = launch_count - 1; i >= 0; --i)
+        if (launched[i] == s)
+            return ready_rc[i];
+    return ECONNREFUSED;
+}
+void Socket_connectComplete(SOCKET s)
+{
+    (void)s;
+    ++complete_count;
+}
+int Socket_close(SOCKET s)
+{
+    if (s < 100 || s >= 164 || !live[s - 100])
+    {
+        fprintf(stderr, "double/invalid close\n");
+        abort();
+    }
+    live[s - 100] = 0;
+    ++close_count;
+    return 0;
+}
+int Socket_interrupt(void)
+{
+    ++interrupt_count;
+    return 0;
+}
+
+static void reset(void)
+{
+    int i;
+    for (i = 0; i < 64; ++i)
+        if (live[i])
+        {
+            fprintf(stderr, "socket leak\n");
+            abort();
+        }
+    resolve_count = 0;
+    now_ms = 0;
+    scenario = 0;
+    launch_count = close_count = complete_count = interrupt_count = 0;
+    next_socket = 100;
+    memset(launched, 0, sizeof(launched));
+    memset(registration_ids, 0, sizeof(registration_ids));
+    memset(launch_time, 0, sizeof(launch_time));
+    memset(launch_owner, 0, sizeof(launch_owner));
+    memset(ready_rc, 0, sizeof(ready_rc));
+}
+static SocketConnect* start(const char* host, int timeout)
+{
+    SocketConnect* a = NULL;
+    START_TIME_TYPE t = START_TIME_ZERO;
+    CHECK(SocketConnect_start(&a, host, strlen(host), 1883, t, (ELAPSED_TIME_TYPE)timeout) ==
+          EINPROGRESS);
+    return a;
+}
+static int test_delay_order(void)
+{
+    SocketConnect* a;
+    reset();
+    a = start("v4v6", 1000);
+    CHECK(a && launch_count == 1 && launch_family[0] == AF_INET);
+    now_ms = 199;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 1);
+    now_ms = 200;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 2 && launch_family[1] == AF_INET6);
+    SocketConnect_cancel(&a);
+    return 1;
+}
+static int test_symmetric_delay(void)
+{
+    SocketConnect* a;
+    reset();
+    a = start("v6v4", 1000);
+    CHECK(launch_count == 1 && launch_family[0] == AF_INET6);
+    now_ms = 200;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 2 && launch_family[1] == AF_INET);
+    SocketConnect_cancel(&a);
+    return 1;
+}
+static int test_slow_preferred_wins(void)
+{
+    SocketConnect* a;
+    SOCKET w;
+    int e;
+    reset();
+    a = start("pair", 1000);
+    CHECK(launch_count == 1);
+    now_ms = 200;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 2);
+    SocketConnect_process(launched[0], registration_ids[0]);
+    CHECK(SocketConnect_takeResult(&a, &w, &e) && e == 0 && w == launched[0] &&
+          complete_count == 1);
+    Socket_close(w);
+    return 1;
+}
+static int test_blackhole_rotation(void)
+{
+    SocketConnect* a;
+    int before;
+    reset();
+    a = start("v4", 1000);
+    CHECK(launch_count == 1);
+    now_ms = 500;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 2 && launch_family[1] == AF_INET);
+    before = close_count;
+    SocketConnect_cancel(&a);
+    CHECK(close_count == before + 1);
+    SocketConnect_cancel(&a);
+    CHECK(close_count == before + 1);
+    return 1;
+}
+static int test_immediate_limit_and_chain(void)
+{
+    SocketConnect* a;
+    reset();
+    scenario = 4;
+    a = start("v4", 1000);
+    CHECK(launch_count == 1);
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 9);
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 10);
+    CHECK(SocketConnect_timeout(1000) == 0);
+    SocketConnect_cancel(&a);
+    return 1;
+}
+static int test_timeout_and_dns(void)
+{
+    SocketConnect* a;
+    SOCKET w;
+    int e;
+    reset();
+    a = start("v4", 100);
+    now_ms = 100;
+    SocketConnect_process(0, 0);
+    CHECK(SocketConnect_takeResult(&a, &w, &e) && e == ETIMEDOUT);
+    CHECK(!SocketConnect_takeResult(&a, &w, &e));
+    reset();
+    scenario = 9;
+    a = start("dns", 100);
+    CHECK(SocketConnect_takeResult(&a, &w, &e) && e == SOCKET_ERROR);
+    return 1;
+}
+static int test_single_winner_and_cancel_reuse(void)
+{
+    SocketConnect *a, *b;
+    SOCKET w;
+    int e;
+    reset();
+    a = start("pair", 1000);
+    now_ms = 200;
+    SocketConnect_process(0, 0);
+    SocketConnect_process(launched[0], registration_ids[0]);
+    CHECK(SocketConnect_takeResult(&a, &w, &e));
+    SocketConnect_process(launched[1], registration_ids[1]);
+    CHECK(complete_count == 1);
+    Socket_close(w);
+    reset();
+    a = start("pair", 1000);
+    {
+        SOCKET old = launched[0];
+        uint64_t registration_id = registration_ids[0];
+        SocketConnect_cancel(&a);
+        CHECK(close_count == 1);
+        b = start("pair", 1000);
+        CHECK(launch_count == 2);
+        CHECK(launched[1] == old && registration_ids[1] != registration_id);
+        SocketConnect_process(old, registration_id);
+        CHECK(!SocketConnect_takeResult(&b, &w, &e));
+        SocketConnect_cancel(&b);
+    }
+    return 1;
+}
+static int test_fairness(void)
+{
+    SocketConnect *a, *b;
+    int i, counts[3] = {0};
+    reset();
+    scenario = 4;
+    a = start("v4", 1000);
+    b = start("v4", 1000);
+    CHECK(launch_count == 2);
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 10);
+    for (i = 2; i < launch_count; ++i)
+        ++counts[launch_owner[i]];
+    CHECK(counts[1] == 4 && counts[2] == 4);
+    SocketConnect_cancel(&a);
+    SocketConnect_cancel(&b);
+    return 1;
+}
+static int test_budget_boundaries(void)
+{
+    SocketConnect* a;
+    SOCKET winner;
+    int error;
+    reset();
+    a = start("mixed", 1000);
+    CHECK(launch_count == 1 && SocketConnect_timeout(1000) == 200);
+    now_ms = 200;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 2 && close_count == 0);
+    now_ms = 499;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 2 && SocketConnect_timeout(1000) == 1);
+    now_ms = 500;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 3 && launch_family[2] == AF_INET6 && launch_time[2] == 500);
+    now_ms = 599;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 3);
+    now_ms = 600;
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 4 && launch_family[3] == AF_INET && launch_time[3] == 600);
+    CHECK(close_count == 2);
+    now_ms = 1000;
+    SocketConnect_process(0, 0);
+    CHECK(SocketConnect_takeResult(&a, &winner, &error) && error == ETIMEDOUT && close_count == 4);
+    reset();
+    scenario = 10;
+    a = start("pair", 100);
+    CHECK(launch_count == 0);
+    CHECK(SocketConnect_takeResult(&a, &winner, &error) && error == ETIMEDOUT);
+    return 1;
+}
+static int test_exhaustion_at_dispatch_limit(void)
+{
+    SocketConnect* a;
+    SOCKET winner;
+    int error;
+    reset();
+    scenario = 4;
+    a = start("nine", 1000);
+    SocketConnect_process(0, 0);
+    CHECK(launch_count == 9 && close_count == 9);
+    CHECK(SocketConnect_takeResult(&a, &winner, &error) && error == ECONNREFUSED);
+    return 1;
+}
+static int test_immediate_and_delayed_failure(void)
+{
+    SocketConnect* a;
+    SOCKET winner;
+    int error;
+    reset();
+    scenario = 5;
+    a = start("pair", 1000);
+    CHECK(SocketConnect_takeResult(&a, &winner, &error) && !error && launch_count == 1);
+    Socket_close(winner);
+    reset();
+    a = start("pair", 1000);
+    now_ms = 50;
+    ready_rc[0] = ECONNREFUSED;
+    SocketConnect_process(launched[0], registration_ids[0]);
+    CHECK(launch_count == 2 && launch_family[1] == AF_INET6 && launch_time[1] == 50);
+    SocketConnect_process(launched[1], registration_ids[1]);
+    CHECK(SocketConnect_takeResult(&a, &winner, &error) && !error);
+    Socket_close(winner);
+    return 1;
+}
+int main(void)
+{
+    int passed = 0;
+    passed += test_delay_order();
+    passed += test_symmetric_delay();
+    passed += test_slow_preferred_wins();
+    passed += test_blackhole_rotation();
+    passed += test_immediate_limit_and_chain();
+    passed += test_timeout_and_dns();
+    passed += test_single_winner_and_cancel_reuse();
+    passed += test_fairness();
+    passed += test_budget_boundaries();
+    passed += test_exhaustion_at_dispatch_limit();
+    passed += test_immediate_and_delayed_failure();
+    reset();
+    printf("socket_connect tests: %d passed, %d failed\n", passed, failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
When a resolved TCP address silently drops connection attempts, waiting on it can consume the connection timeout before another address or address family gets a chance. This adds bounded IPv4/IPv6 candidate racing to both MQTTClient and MQTTAsync.

- Preserve resolver order within each family, start the other family after 200 ms (or earlier when the preferred family is exhausted), and keep at most two candidate sockets active.
- Divide the remaining connection budget among same-family candidates and limit new launches to eight per event-loop dispatch. Cancel losing candidates and validate registration identities to reject readiness events from reused socket descriptors.
- Keep TLS, WebSocket, and proxy protocol handling after TCP selection. Add `PAHO_WITH_HAPPY_EYEBALLS` (default ON); setting it OFF retains the legacy TCP connection strategy.
- Add 11 deterministic scheduler cases covering family order, delayed fallback, stalled-candidate rotation, deadlines, cancellation, descriptor reuse, and scheduling fairness.

The change is based on current `develop`. It also adapts the new async failure path to the upstream `sendDisconnect` argument and guards interrupt-socket cleanup when initialization fails.

### Validation

Windows x64, MinGW GCC 10.3, CMake/Ninja, Debug:

- Built shared and static libraries plus all test executables with SSL disabled.
- Built with OpenSSL 3.6.1 and `PAHO_HIGH_PERFORMANCE=ON` across all four combinations of Happy Eyeballs ON/OFF and poll/select.
- `socket-connect-state` (11 cases) and upstream `test_unit_coverage` passed in every configuration.
- Against the upstream `paho.mqtt.testing` broker on loopback, eight MQTT 3.1.1/5.0 sync/async connect-subscribe-receive tests passed using poll, and seven mutual-TLS/WebSocket tests passed using select, including shared/static variants.
- `git diff --check` passed.

MinGW configuration used `-D_WIN32_WINNT=0x0600 -DWINVER=0x0600 -D_WINDOWS`. The full broker test suite, Linux/macOS runtime tests, and real dual-stack packet-drop scenarios have not been run locally. DNS resolution remains synchronous; the scheduler uses the connection budget remaining after resolution.

ECA is signed and the commit includes `Signed-off-by`. Codex was used to prepare this contribution.
